### PR TITLE
perf(evm): inline general u256 DIV/MOD to eliminate runtime call

### DIFF
--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -1436,6 +1436,7 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDivModGeneral(
     const Operand &DividendOp, const Operand &DivisorOp, bool WantQuotient) {
   MType *I64Type = &Ctx.I64Type;
   MInstruction *Zero = createIntConstInstruction(I64Type, 0);
+  MInstruction *One = createIntConstInstruction(I64Type, 1);
 
   U256Inst A = extractU256Operand(DividendOp);
   U256Inst B = extractU256Operand(DivisorOp);
@@ -1447,10 +1448,13 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDivModGeneral(
   MInstruction *HasUpperLimbs = createInstruction<CmpInstruction>(
       false, CmpInstruction::ICMP_NE, I64Type, UpperOr, Zero);
 
-  // Also check if B[0] is zero (combined with upper limbs being zero means
-  // divisor == 0 → EVM returns 0)
+  // Guard B[0] against zero to prevent hardware divide-by-zero trap.
+  // EVM DIV/MOD(a, 0) = 0, but x86 DIV with zero divisor raises SIGFPE.
+  // Replace zero divisor with 1 (harmless), then select result to 0 afterward.
   MInstruction *IsB0Zero = createInstruction<CmpInstruction>(
       false, CmpInstruction::ICMP_EQ, I64Type, B[0], Zero);
+  MInstruction *SafeB0 =
+      createInstruction<SelectInstruction>(false, I64Type, IsB0Zero, One, B[0]);
 
   // Result variables for cross-BB communication
   U256Var ResultVars = {};
@@ -1473,57 +1477,50 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDivModGeneral(
     return Values;
   };
 
-  // Branch structure:
-  //   if (HasUpperLimbs) goto MultiLimbBB else goto SingleLimbCheckBB
-  //   SingleLimbCheckBB:
-  //     if (IsB0Zero) goto ZeroDivisorBB else goto SingleLimbBB
-  //   ZeroDivisorBB: result = 0; goto AfterBB
-  //   SingleLimbBB: inline cascading 128/64 div; goto AfterBB
+  // Branch structure (3-block, matches handleDiv pattern):
+  //   if (HasUpperLimbs) goto MultiLimbBB else goto SingleLimbBB
+  //   SingleLimbBB: inline cascading 128/64 div with SafeB0; goto AfterBB
   //   MultiLimbBB: runtime call; goto AfterBB
-  //   AfterBB: phi
+  //   AfterBB: load result
   MBasicBlock *MultiLimbBB = createBasicBlock();
-  MBasicBlock *SingleLimbCheckBB = createBasicBlock();
-  MBasicBlock *ZeroDivisorBB = createBasicBlock();
   MBasicBlock *SingleLimbBB = createBasicBlock();
   MBasicBlock *AfterBB = createBasicBlock();
 
   createInstruction<BrIfInstruction>(true, Ctx, HasUpperLimbs, MultiLimbBB,
-                                     SingleLimbCheckBB);
-  addSuccessor(MultiLimbBB);
-  addSuccessor(SingleLimbCheckBB);
-
-  // --- SingleLimbCheckBB: check for zero divisor ---
-  setInsertBlock(SingleLimbCheckBB);
-  createInstruction<BrIfInstruction>(true, Ctx, IsB0Zero, ZeroDivisorBB,
                                      SingleLimbBB);
-  addSuccessor(ZeroDivisorBB);
+  addSuccessor(MultiLimbBB);
   addSuccessor(SingleLimbBB);
 
-  // --- ZeroDivisorBB: divisor == 0, EVM returns 0 ---
-  setInsertBlock(ZeroDivisorBB);
-  U256Inst ZeroResult = {Zero, Zero, Zero, Zero};
-  storeResult(ZeroResult);
-  createInstruction<BrInstruction>(true, Ctx, AfterBB);
-  addSuccessor(AfterBB);
-
   // --- SingleLimbBB: 1-limb divisor, cascading 128/64 division ---
+  // Uses SafeB0 (guaranteed non-zero) to avoid hardware DIV-by-zero.
+  // If B[0] was actually zero, IsB0Zero selects result to 0 afterward.
   setInsertBlock(SingleLimbBB);
-  // Cascading: (0:A[3])/B[0], (R3:A[2])/B[0], (R2:A[1])/B[0],
-  // (R1:A[0])/B[0]
-  MInstruction *Div3 = createEvmUdiv128By64(Zero, A[3], B[0]);
+  // Cascading: (0:A[3])/SafeB0, (R3:A[2])/SafeB0, ...
+  MInstruction *Div3 = createEvmUdiv128By64(Zero, A[3], SafeB0);
   MInstruction *Rem3 = createEvmUrem128By64(Div3);
-  MInstruction *Div2 = createEvmUdiv128By64(Rem3, A[2], B[0]);
+  MInstruction *Div2 = createEvmUdiv128By64(Rem3, A[2], SafeB0);
   MInstruction *Rem2 = createEvmUrem128By64(Div2);
-  MInstruction *Div1 = createEvmUdiv128By64(Rem2, A[1], B[0]);
+  MInstruction *Div1 = createEvmUdiv128By64(Rem2, A[1], SafeB0);
   MInstruction *Rem1 = createEvmUrem128By64(Div1);
-  MInstruction *Div0 = createEvmUdiv128By64(Rem1, A[0], B[0]);
+  MInstruction *Div0 = createEvmUdiv128By64(Rem1, A[0], SafeB0);
   MInstruction *Rem0 = createEvmUrem128By64(Div0);
 
   if (WantQuotient) {
-    U256Inst QuotResult = {Div0, Div1, Div2, Div3};
+    // Select each quotient limb to 0 when divisor was zero
+    U256Inst QuotResult = {createInstruction<SelectInstruction>(
+                               false, I64Type, IsB0Zero, Zero, Div0),
+                           createInstruction<SelectInstruction>(
+                               false, I64Type, IsB0Zero, Zero, Div1),
+                           createInstruction<SelectInstruction>(
+                               false, I64Type, IsB0Zero, Zero, Div2),
+                           createInstruction<SelectInstruction>(
+                               false, I64Type, IsB0Zero, Zero, Div3)};
     storeResult(QuotResult);
   } else {
-    U256Inst RemResult = {Rem0, Zero, Zero, Zero};
+    // Select remainder to 0 when divisor was zero (only limb 0 matters)
+    U256Inst RemResult = {createInstruction<SelectInstruction>(
+                              false, I64Type, IsB0Zero, Zero, Rem0),
+                          Zero, Zero, Zero};
     storeResult(RemResult);
   }
   createInstruction<BrInstruction>(true, Ctx, AfterBB);

--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -1432,6 +1432,125 @@ EVMMirBuilder::handleModU64Dividend(uint64_t Dividend,
   return Operand(Result, EVMType::UINT256);
 }
 
+typename EVMMirBuilder::Operand EVMMirBuilder::handleDivModGeneral(
+    const Operand &DividendOp, const Operand &DivisorOp, bool WantQuotient) {
+  MType *I64Type = &Ctx.I64Type;
+  MInstruction *Zero = createIntConstInstruction(I64Type, 0);
+
+  U256Inst A = extractU256Operand(DividendOp);
+  U256Inst B = extractU256Operand(DivisorOp);
+
+  // Check if divisor upper limbs are all zero (runtime 1-limb divisor)
+  MInstruction *UpperOr = createInstruction<BinaryInstruction>(
+      false, OP_or, I64Type, B[1],
+      createInstruction<BinaryInstruction>(false, OP_or, I64Type, B[2], B[3]));
+  MInstruction *HasUpperLimbs = createInstruction<CmpInstruction>(
+      false, CmpInstruction::ICMP_NE, I64Type, UpperOr, Zero);
+
+  // Also check if B[0] is zero (combined with upper limbs being zero means
+  // divisor == 0 → EVM returns 0)
+  MInstruction *IsB0Zero = createInstruction<CmpInstruction>(
+      false, CmpInstruction::ICMP_EQ, I64Type, B[0], Zero);
+
+  // Result variables for cross-BB communication
+  U256Var ResultVars = {};
+  for (size_t I = 0; I < EVM_ELEMENTS_COUNT; ++I) {
+    ResultVars[I] = CurFunc->createVariable(I64Type);
+  }
+
+  auto storeResult = [&](const U256Inst &Values) {
+    for (size_t I = 0; I < EVM_ELEMENTS_COUNT; ++I) {
+      createInstruction<DassignInstruction>(true, &(Ctx.VoidType), Values[I],
+                                            ResultVars[I]->getVarIdx());
+    }
+  };
+
+  auto loadResult = [&]() -> U256Inst {
+    U256Inst Values = {};
+    for (size_t I = 0; I < EVM_ELEMENTS_COUNT; ++I) {
+      Values[I] = loadVariable(ResultVars[I]);
+    }
+    return Values;
+  };
+
+  // Branch structure:
+  //   if (HasUpperLimbs) goto MultiLimbBB else goto SingleLimbCheckBB
+  //   SingleLimbCheckBB:
+  //     if (IsB0Zero) goto ZeroDivisorBB else goto SingleLimbBB
+  //   ZeroDivisorBB: result = 0; goto AfterBB
+  //   SingleLimbBB: inline cascading 128/64 div; goto AfterBB
+  //   MultiLimbBB: runtime call; goto AfterBB
+  //   AfterBB: phi
+  MBasicBlock *MultiLimbBB = createBasicBlock();
+  MBasicBlock *SingleLimbCheckBB = createBasicBlock();
+  MBasicBlock *ZeroDivisorBB = createBasicBlock();
+  MBasicBlock *SingleLimbBB = createBasicBlock();
+  MBasicBlock *AfterBB = createBasicBlock();
+
+  createInstruction<BrIfInstruction>(true, Ctx, HasUpperLimbs, MultiLimbBB,
+                                     SingleLimbCheckBB);
+  addSuccessor(MultiLimbBB);
+  addSuccessor(SingleLimbCheckBB);
+
+  // --- SingleLimbCheckBB: check for zero divisor ---
+  setInsertBlock(SingleLimbCheckBB);
+  createInstruction<BrIfInstruction>(true, Ctx, IsB0Zero, ZeroDivisorBB,
+                                     SingleLimbBB);
+  addSuccessor(ZeroDivisorBB);
+  addSuccessor(SingleLimbBB);
+
+  // --- ZeroDivisorBB: divisor == 0, EVM returns 0 ---
+  setInsertBlock(ZeroDivisorBB);
+  U256Inst ZeroResult = {Zero, Zero, Zero, Zero};
+  storeResult(ZeroResult);
+  createInstruction<BrInstruction>(true, Ctx, AfterBB);
+  addSuccessor(AfterBB);
+
+  // --- SingleLimbBB: 1-limb divisor, cascading 128/64 division ---
+  setInsertBlock(SingleLimbBB);
+  // Cascading: (0:A[3])/B[0], (R3:A[2])/B[0], (R2:A[1])/B[0],
+  // (R1:A[0])/B[0]
+  MInstruction *Div3 = createEvmUdiv128By64(Zero, A[3], B[0]);
+  MInstruction *Rem3 = createEvmUrem128By64(Div3);
+  MInstruction *Div2 = createEvmUdiv128By64(Rem3, A[2], B[0]);
+  MInstruction *Rem2 = createEvmUrem128By64(Div2);
+  MInstruction *Div1 = createEvmUdiv128By64(Rem2, A[1], B[0]);
+  MInstruction *Rem1 = createEvmUrem128By64(Div1);
+  MInstruction *Div0 = createEvmUdiv128By64(Rem1, A[0], B[0]);
+  MInstruction *Rem0 = createEvmUrem128By64(Div0);
+
+  if (WantQuotient) {
+    U256Inst QuotResult = {Div0, Div1, Div2, Div3};
+    storeResult(QuotResult);
+  } else {
+    U256Inst RemResult = {Rem0, Zero, Zero, Zero};
+    storeResult(RemResult);
+  }
+  createInstruction<BrInstruction>(true, Ctx, AfterBB);
+  addSuccessor(AfterBB);
+
+  // --- MultiLimbBB: multi-limb divisor, fall back to runtime ---
+  setInsertBlock(MultiLimbBB);
+  const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  Operand RuntimeResult;
+  if (WantQuotient) {
+    RuntimeResult = callRuntimeFor<const intx::uint256 *, const intx::uint256 &,
+                                   const intx::uint256 &>(
+        RuntimeFunctions.GetDiv, DividendOp, DivisorOp);
+  } else {
+    RuntimeResult = callRuntimeFor<const intx::uint256 *, const intx::uint256 &,
+                                   const intx::uint256 &>(
+        RuntimeFunctions.GetMod, DividendOp, DivisorOp);
+  }
+  storeResult(extractU256Operand(RuntimeResult));
+  createInstruction<BrInstruction>(true, Ctx, AfterBB);
+  addSuccessor(AfterBB);
+
+  // --- AfterBB: merge results ---
+  setInsertBlock(AfterBB);
+  return Operand(loadResult(), EVMType::UINT256);
+}
+
 typename EVMMirBuilder::Operand EVMMirBuilder::handleMul(Operand MultiplicandOp,
                                                          Operand MultiplierOp) {
   // Phase 0: Constant folding
@@ -1627,10 +1746,7 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDiv(Operand DividendOp,
     return handleDivU64Dividend(A, DivisorOp);
   }
 
-  const auto &RuntimeFunctions = getRuntimeFunctionTable();
-  return callRuntimeFor<const intx::uint256 *, const intx::uint256 &,
-                        const intx::uint256 &>(RuntimeFunctions.GetDiv,
-                                               DividendOp, DivisorOp);
+  return handleDivModGeneral(DividendOp, DivisorOp, /*WantQuotient=*/true);
 }
 
 typename EVMMirBuilder::Operand EVMMirBuilder::handleSDiv(Operand DividendOp,
@@ -1716,10 +1832,7 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMod(Operand DividendOp,
     return handleModU64Dividend(A, DivisorOp);
   }
 
-  const auto &RuntimeFunctions = getRuntimeFunctionTable();
-  return callRuntimeFor<const intx::uint256 *, const intx::uint256 &,
-                        const intx::uint256 &>(RuntimeFunctions.GetMod,
-                                               DividendOp, DivisorOp);
+  return handleDivModGeneral(DividendOp, DivisorOp, /*WantQuotient=*/false);
 }
 
 typename EVMMirBuilder::Operand EVMMirBuilder::handleSMod(Operand DividendOp,

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -808,6 +808,11 @@ private:
   Operand handleDivU64Dividend(uint64_t Dividend, const Operand &DivisorOp);
   Operand handleModU64Dividend(uint64_t Dividend, const Operand &DivisorOp);
 
+  // General u256 div/mod with runtime divisor-size branching.
+  // WantQuotient=true returns quotient (DIV), false returns remainder (MOD).
+  Operand handleDivModGeneral(const Operand &DividendOp,
+                              const Operand &DivisorOp, bool WantQuotient);
+
   // ==================== EVM to MIR Opcode Mapping ====================
 
   Opcode getMirOpcode(BinaryOperator BinOpr);


### PR DESCRIPTION
## Summary
- Replace runtime call fallback in handleDiv and handleMod with inline runtime divisor-size branching
- At runtime, detect if divisor fits in a single 64-bit limb (upper 3 limbs all zero) and use cascading 128/64 division inline
- Handle divisor==0 inline (EVM spec: return 0) to avoid entering the runtime for a common edge case
- Multi-limb divisors still fall back to the runtime call

## Test plan
- [x] evmone-unittests multipass (223 tests)
- [x] evmone-unittests interpreter (215 tests)
- [x] evmone-statetest multipass Cancun (2723 tests)
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)