### PR TITLE
perf(evm): add value-range narrowing for u256 arithmetic

### DIFF
--- a/src/compiler/evm_frontend/evm_mir_compiler.cpp
+++ b/src/compiler/evm_frontend/evm_mir_compiler.cpp
@@ -1441,6 +1441,21 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMul(Operand MultiplicandOp,
     return Operand(intxToU256Value(A * B));
   }
 
+  // Phase 1: Range-based u64×u64 → u128 fast path
+  // When both operands provably fit in u64, a single 64×64→128 multiply
+  // replaces the expensive 4×4 schoolbook multiplication.
+  if (Operand::bothFitU64(MultiplicandOp, MultiplierOp) &&
+      !MultiplicandOp.isConstant() && !MultiplierOp.isConstant()) {
+    U256Inst A = extractU256Operand(MultiplicandOp);
+    U256Inst B = extractU256Operand(MultiplierOp);
+    MType *I64Type = &Ctx.I64Type;
+    MInstruction *Zero = createIntConstInstruction(I64Type, 0);
+    MInstruction *MulLo = createEvmUmul128(A[0], B[0]);
+    MInstruction *MulHi = createEvmUmul128Hi(MulLo);
+    U256Inst Result = {MulLo, MulHi, Zero, Zero};
+    return Operand(Result, EVMType::UINT256, ValueRange::U128);
+  }
+
   // Phase 4: u64 fast path - one operand fits in u64 (4x1 multiplication)
   bool AIsU64 = MultiplicandOp.isConstU64();
   bool BIsU64 = MultiplierOp.isConstU64();
@@ -1552,6 +1567,31 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleDiv(Operand DividendOp,
       Operand ShiftOp(U256Value{ShiftAmt, 0, 0, 0});
       return handleShift<BinaryOperator::BO_SHR_U>(ShiftOp, DividendOp);
     }
+  }
+
+  // Range-based u64÷u64 fast path: single OP_udiv with div-by-zero guard.
+  // DIV(u64, u64) → u64 result.  Inserted before the isConstU64() path so
+  // that non-constant operands with proven narrow range benefit too.
+  if (Operand::bothFitU64(DividendOp, DivisorOp) && !DividendOp.isConstant() &&
+      !DivisorOp.isConstant()) {
+    U256Inst A = extractU256Operand(DividendOp);
+    U256Inst B = extractU256Operand(DivisorOp);
+    MType *I64Type = &Ctx.I64Type;
+    MInstruction *Zero = createIntConstInstruction(I64Type, 0);
+    MInstruction *One = createIntConstInstruction(I64Type, 1);
+
+    // Guard against div-by-zero: EVM DIV(x, 0) = 0, but x86 traps
+    MInstruction *IsZero = createInstruction<CmpInstruction>(
+        false, CmpInstruction::ICMP_EQ, I64Type, B[0], Zero);
+    MInstruction *SafeB =
+        createInstruction<SelectInstruction>(false, I64Type, IsZero, One, B[0]);
+    MInstruction *Quotient = createInstruction<BinaryInstruction>(
+        false, OP_udiv, I64Type, A[0], SafeB);
+    MInstruction *DivResult = createInstruction<SelectInstruction>(
+        false, I64Type, IsZero, Zero, Quotient);
+
+    U256Inst Result = {DivResult, Zero, Zero, Zero};
+    return Operand(Result, EVMType::UINT256, ValueRange::U64);
   }
 
   // u64 divisor: inline cascading 128/64 division
@@ -1701,6 +1741,30 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleMod(Operand DividendOp,
       Operand MaskOp(intxToU256Value(D - 1));
       return handleBitwiseOp<BinaryOperator::BO_AND>(DividendOp, MaskOp);
     }
+  }
+
+  // Range-based u64%u64 fast path: single OP_urem with div-by-zero guard.
+  // MOD(u64, u64) → u64 result (remainder < divisor).
+  if (Operand::bothFitU64(DividendOp, DivisorOp) && !DividendOp.isConstant() &&
+      !DivisorOp.isConstant()) {
+    U256Inst A = extractU256Operand(DividendOp);
+    U256Inst B = extractU256Operand(DivisorOp);
+    MType *I64Type = &Ctx.I64Type;
+    MInstruction *Zero = createIntConstInstruction(I64Type, 0);
+    MInstruction *One = createIntConstInstruction(I64Type, 1);
+
+    // Guard against div-by-zero: EVM MOD(x, 0) = 0
+    MInstruction *IsZero = createInstruction<CmpInstruction>(
+        false, CmpInstruction::ICMP_EQ, I64Type, B[0], Zero);
+    MInstruction *SafeB =
+        createInstruction<SelectInstruction>(false, I64Type, IsZero, One, B[0]);
+    MInstruction *Remainder = createInstruction<BinaryInstruction>(
+        false, OP_urem, I64Type, A[0], SafeB);
+    MInstruction *ModResult = createInstruction<SelectInstruction>(
+        false, I64Type, IsZero, Zero, Remainder);
+
+    U256Inst Result = {ModResult, Zero, Zero, Zero};
+    return Operand(Result, EVMType::UINT256, ValueRange::U64);
   }
 
   // u64 divisor: inline cascading 128/64 mod
@@ -2577,7 +2641,7 @@ EVMMirBuilder::handleCompareEqU64(const Operand &FullOp, uint64_t U64Val) {
   for (size_t I = 1; I < EVM_ELEMENTS_COUNT; ++I) {
     Result[I] = Zero;
   }
-  return Operand(Result, EVMType::UINT256);
+  return Operand(Result, EVMType::UINT256, ValueRange::U64);
 }
 
 typename EVMMirBuilder::Operand
@@ -2612,7 +2676,7 @@ EVMMirBuilder::handleCompareLtRhsU64(const Operand &LHSOp, uint64_t RhsU64) {
   for (size_t I = 1; I < EVM_ELEMENTS_COUNT; ++I) {
     Result[I] = Zero;
   }
-  return Operand(Result, EVMType::UINT256);
+  return Operand(Result, EVMType::UINT256, ValueRange::U64);
 }
 
 typename EVMMirBuilder::Operand
@@ -2648,7 +2712,7 @@ EVMMirBuilder::handleCompareGtRhsU64(const Operand &LHSOp, uint64_t RhsU64) {
   for (size_t I = 1; I < EVM_ELEMENTS_COUNT; ++I) {
     Result[I] = Zero;
   }
-  return Operand(Result, EVMType::UINT256);
+  return Operand(Result, EVMType::UINT256, ValueRange::U64);
 }
 
 typename EVMMirBuilder::Operand
@@ -3264,7 +3328,8 @@ typename EVMMirBuilder::Operand EVMMirBuilder::handleByte(Operand IndexOp,
     for (size_t I = 1; I < EVM_ELEMENTS_COUNT; ++I) {
       ResultComponents[I] = Zero;
     }
-    return Operand(ResultComponents, EVMType::UINT256);
+    // BYTE always produces a single byte value (0..255)
+    return Operand(ResultComponents, EVMType::UINT256, ValueRange::U64);
   };
 
   if (IndexOp.isConstant() && ValueOp.isConstant()) {

--- a/src/compiler/evm_frontend/evm_mir_compiler.h
+++ b/src/compiler/evm_frontend/evm_mir_compiler.h
@@ -115,6 +115,14 @@ public:
   using U256Value = std::array<uint64_t, EVM_ELEMENTS_COUNT>;
   using U256ConstInt = std::array<MConstantInt *, EVM_ELEMENTS_COUNT>;
 
+  // Range classification for u256 operands.  Narrower ranges enable
+  // single-instruction fast paths instead of expensive multi-limb arithmetic.
+  enum class ValueRange : uint8_t {
+    U64,  // Fits in 64 bits  (limbs [1..3] == 0)
+    U128, // Fits in 128 bits (limbs [2..3] == 0)
+    U256, // Full 256 bits — conservative default
+  };
+
   EVMMirBuilder(CompilerContext &Context, MFunction &MFunc);
 
   class Operand {
@@ -129,6 +137,13 @@ public:
       ZEN_ASSERT(Type == EVMType::UINT256 && "Multi-component only for U256");
     }
 
+    // Constructor for U256 multi-component with explicit range
+    Operand(U256Inst Components, EVMType Type, ValueRange Range)
+        : Type(Type), Range(Range), U256Components(Components),
+          IsU256MultiComponent(true) {
+      ZEN_ASSERT(Type == EVMType::UINT256 && "Multi-component only for U256");
+    }
+
     Operand(U256Var VarComponents, EVMType Type)
         : Type(Type), U256VarComponents(VarComponents),
           IsU256MultiComponent(true) {
@@ -136,7 +151,16 @@ public:
     }
 
     Operand(const U256Value &ConstValue)
-        : Type(EVMType::UINT256), ConstValue(ConstValue), IsConstant(true) {}
+        : Type(EVMType::UINT256), ConstValue(ConstValue), IsConstant(true) {
+      // Auto-derive range from constant value
+      if (ConstValue[1] == 0 && ConstValue[2] == 0 && ConstValue[3] == 0) {
+        Range = ValueRange::U64;
+      } else if (ConstValue[2] == 0 && ConstValue[3] == 0) {
+        Range = ValueRange::U128;
+      } else {
+        Range = ValueRange::U256;
+      }
+    }
 
     MInstruction *getInstr() const { return Instr; }
     Variable *getVar() const { return Var; }
@@ -167,6 +191,14 @@ public:
       return ConstValue;
     }
 
+    // Provable value range — narrower ranges enable fast arithmetic paths
+    ValueRange getRange() const { return Range; }
+
+    // Check whether both operands provably fit in u64
+    static bool bothFitU64(const Operand &A, const Operand &B) {
+      return A.getRange() == ValueRange::U64 && B.getRange() == ValueRange::U64;
+    }
+
     constexpr bool isReg() { return false; }
     constexpr bool isTempReg() { return true; }
 
@@ -174,6 +206,7 @@ public:
     MInstruction *Instr = nullptr;
     Variable *Var = nullptr;
     EVMType Type = EVMType::VOID;
+    ValueRange Range = ValueRange::U256;
 
     // For EVMU256Type: 4 I64 components [0]=low, [1]=mid-low, [2]=mid-high,
     // [3]=high
@@ -241,6 +274,29 @@ public:
         ZEN_ASSERT_TODO();
       }
       return Operand(intxToU256Value(Res));
+    }
+
+    // Phase 1: Range-based u64 fast path for ADD
+    // When both operands provably fit in u64, emit single ADD + carry
+    // instead of the full 4-limb ADC chain.  Result fits in u128.
+    if constexpr (Operator == BinaryOperator::BO_ADD) {
+      if (Operand::bothFitU64(LHSOp, RHSOp) && !LHSOp.isConstant() &&
+          !RHSOp.isConstant()) {
+        MType *MirI64Type =
+            EVMFrontendContext::getMIRTypeFromEVMType(EVMType::UINT64);
+        MInstruction *Zero = createIntConstInstruction(MirI64Type, 0);
+        U256Inst LHS = extractU256Operand(LHSOp);
+        U256Inst RHS = extractU256Operand(RHSOp);
+        MInstruction *Sum = createInstruction<BinaryInstruction>(
+            false, OP_add, MirI64Type, LHS[0], RHS[0]);
+        Sum = protectUnsafeValue(Sum, MirI64Type);
+        // Carry = (Sum < LHS[0]) ? 1 : 0
+        MInstruction *CarryCmp = createInstruction<CmpInstruction>(
+            false, CmpInstruction::ICMP_ULT, MirI64Type, Sum, LHS[0]);
+        MInstruction *CarryExt = zeroExtendToI64(CarryCmp);
+        U256Inst Result = {Sum, CarryExt, Zero, Zero};
+        return Operand(Result, EVMType::UINT256, ValueRange::U128);
+      }
     }
 
     // Phase 2: u64 fast path for ADD - share zero const for upper RHS limbs
@@ -403,7 +459,8 @@ public:
     }
 
     U256Inst Result = handleCompareImpl<Operator>(LHSOp, RHSOp, &Ctx.I64Type);
-    return Operand(Result, EVMType::UINT256);
+    // Comparison results are always 0 or 1
+    return Operand(Result, EVMType::UINT256, ValueRange::U64);
   }
 
   // EVM bitwise opcode: and, or, xor
@@ -445,7 +502,33 @@ public:
         for (size_t I = 1; I < EVM_ELEMENTS_COUNT; ++I) {
           Result[I] = Zero;
         }
-        return Operand(Result, EVMType::UINT256);
+        return Operand(Result, EVMType::UINT256, ValueRange::U64);
+      }
+
+      // Non-constant AND with a U128 mask: result fits in U128
+      if (LHSOp.getRange() <= ValueRange::U128 ||
+          RHSOp.getRange() <= ValueRange::U128) {
+        // AND narrows to the smaller operand range
+        ValueRange NarrowRange = std::min(LHSOp.getRange(), RHSOp.getRange());
+        U256Inst LHS = extractU256Operand(LHSOp);
+        U256Inst RHS = extractU256Operand(RHSOp);
+        MType *MirI64Type =
+            EVMFrontendContext::getMIRTypeFromEVMType(EVMType::UINT64);
+        MInstruction *Zero = createIntConstInstruction(MirI64Type, 0);
+        U256Inst Result = {};
+        for (size_t I = 0; I < EVM_ELEMENTS_COUNT; ++I) {
+          if (NarrowRange == ValueRange::U64 && I >= 1) {
+            Result[I] = Zero;
+          } else if (NarrowRange == ValueRange::U128 && I >= 2) {
+            Result[I] = Zero;
+          } else {
+            Result[I] = protectUnsafeValue(
+                createInstruction<BinaryInstruction>(false, OP_and, MirI64Type,
+                                                     LHS[I], RHS[I]),
+                MirI64Type);
+          }
+        }
+        return Operand(Result, EVMType::UINT256, NarrowRange);
       }
     }
 


### PR DESCRIPTION
## Summary
- Add ValueRange enum (U64/U128/U256) to Operand class for tracking provable narrowness of u256 values
- Propagate ranges through EVM→MIR translation: constants auto-derive, AND narrows to smaller operand, BYTE/comparisons tagged U64
- Emit narrow single-instruction fast paths for DIV, MOD, MUL, ADD when both operands are provably U64

## Test plan
- [x] evmone-unittests multipass (223 tests)
- [x] evmone-unittests interpreter (215 tests)
- [x] evmone-statetest multipass Cancun (2723 tests)
- [x] Format check passes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>