### PR TITLE
ci: enable Ninja and sccache across test jobs

### DIFF
--- a/.ci/cmake_ci_build.sh
+++ b/.ci/cmake_ci_build.sh
@@ -14,6 +14,7 @@ if [ "${1:-}" = "--" ]; then
     shift
 fi
 
+SOURCE_DIR=${DTVM_CI_SOURCE_DIR:-.}
 USE_NINJA=${DTVM_CI_USE_NINJA:-0}
 USE_SCCACHE=${DTVM_CI_USE_SCCACHE:-0}
 DRY_RUN=${DTVM_CI_DRY_RUN:-0}
@@ -34,7 +35,7 @@ fi
 
 CONFIGURE_CMD=(
     cmake
-    -S .
+    -S "$SOURCE_DIR"
     -B "$BUILD_DIR"
     "${GENERATOR_ARGS[@]}"
     "${LAUNCHER_ARGS[@]}"
@@ -42,6 +43,7 @@ CONFIGURE_CMD=(
 )
 BUILD_CMD=(cmake --build "$BUILD_DIR" -j "$BUILD_JOBS")
 
+echo "DTVM CI CMake source dir: ${SOURCE_DIR}"
 echo "DTVM CI CMake generator: ${USE_NINJA}"
 echo "DTVM CI CMake sccache launcher: ${USE_SCCACHE}"
 

--- a/.ci/cmake_ci_build.sh
+++ b/.ci/cmake_ci_build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <build-dir> [--] [cmake configure args...]" >&2
+    exit 2
+fi
+
+BUILD_DIR=$1
+shift
+
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+
+USE_NINJA=${DTVM_CI_USE_NINJA:-0}
+USE_SCCACHE=${DTVM_CI_USE_SCCACHE:-0}
+DRY_RUN=${DTVM_CI_DRY_RUN:-0}
+BUILD_JOBS=${DTVM_CI_BUILD_JOBS:-16}
+
+GENERATOR_ARGS=()
+if [ "$USE_NINJA" = "1" ]; then
+    GENERATOR_ARGS=(-G Ninja)
+fi
+
+LAUNCHER_ARGS=()
+if [ "$USE_SCCACHE" = "1" ]; then
+    LAUNCHER_ARGS=(
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+    )
+fi
+
+CONFIGURE_CMD=(
+    cmake
+    -S .
+    -B "$BUILD_DIR"
+    "${GENERATOR_ARGS[@]}"
+    "${LAUNCHER_ARGS[@]}"
+    "$@"
+)
+BUILD_CMD=(cmake --build "$BUILD_DIR" -j "$BUILD_JOBS")
+
+echo "DTVM CI CMake generator: ${USE_NINJA}"
+echo "DTVM CI CMake sccache launcher: ${USE_SCCACHE}"
+
+printf '+'
+printf ' %q' "${CONFIGURE_CMD[@]}"
+printf '\n'
+
+if [ "$DRY_RUN" = "1" ]; then
+    printf '+'
+    printf ' %q' "${BUILD_CMD[@]}"
+    printf '\n'
+    exit 0
+fi
+
+if [ "$USE_SCCACHE" = "1" ] && ! command -v sccache >/dev/null 2>&1; then
+    echo "DTVM_CI_USE_SCCACHE=1 but sccache is not in PATH" >&2
+    exit 1
+fi
+
+"${CONFIGURE_CMD[@]}"
+
+printf '+'
+printf ' %q' "${BUILD_CMD[@]}"
+printf '\n'
+"${BUILD_CMD[@]}"

--- a/.ci/cmake_ci_build.sh
+++ b/.ci/cmake_ci_build.sh
@@ -21,16 +21,20 @@ DRY_RUN=${DTVM_CI_DRY_RUN:-0}
 BUILD_JOBS=${DTVM_CI_BUILD_JOBS:-16}
 
 GENERATOR_ARGS=()
+GENERATOR_NAME=default
 if [ "$USE_NINJA" = "1" ]; then
     GENERATOR_ARGS=(-G Ninja)
+    GENERATOR_NAME=Ninja
 fi
 
 LAUNCHER_ARGS=()
+LAUNCHER_NAME=none
 if [ "$USE_SCCACHE" = "1" ]; then
     LAUNCHER_ARGS=(
         -DCMAKE_C_COMPILER_LAUNCHER=sccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
     )
+    LAUNCHER_NAME=sccache
 fi
 
 CONFIGURE_CMD=(
@@ -44,8 +48,8 @@ CONFIGURE_CMD=(
 BUILD_CMD=(cmake --build "$BUILD_DIR" -j "$BUILD_JOBS")
 
 echo "DTVM CI CMake source dir: ${SOURCE_DIR}"
-echo "DTVM CI CMake generator: ${USE_NINJA}"
-echo "DTVM CI CMake sccache launcher: ${USE_SCCACHE}"
+echo "DTVM CI CMake generator: ${GENERATOR_NAME}"
+echo "DTVM CI CMake compiler launcher: ${LAUNCHER_NAME}"
 
 printf '+'
 printf ' %q' "${CONFIGURE_CMD[@]}"

--- a/.ci/print_sccache_stats.py
+++ b/.ci/print_sccache_stats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import numbers
+import shutil
+import subprocess
+import sys
+
+
+def sum_numbers(value):
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, numbers.Number):
+        return int(value)
+    if isinstance(value, dict):
+        return sum(sum_numbers(item) for item in value.values())
+    if isinstance(value, list):
+        return sum(sum_numbers(item) for item in value)
+    return 0
+
+
+def count_bucket(stats, name):
+    value = stats.get(name, {})
+    if isinstance(value, dict) and "counts" in value:
+        value = value["counts"]
+    return sum_numbers(value)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--require-requests", action="store_true")
+    args = parser.parse_args()
+
+    if shutil.which("sccache") is None:
+        print("sccache is not in PATH", file=sys.stderr)
+        return 1 if args.require_requests else 0
+
+    subprocess.run(["sccache", "--show-stats"], check=False)
+
+    stats_json = subprocess.check_output(
+        ["sccache", "--show-stats", "--stats-format=json"],
+        text=True,
+    )
+    data = json.loads(stats_json)
+    stats = data.get("stats", {})
+    compile_requests = int(stats.get("compile_requests") or 0)
+    cache_hits = count_bucket(stats, "cache_hits")
+    cache_misses = count_bucket(stats, "cache_misses")
+
+    print(f"sccache compile_requests={compile_requests}")
+    print(f"sccache aggregate_cache_hits={cache_hits}")
+    print(f"sccache aggregate_cache_misses={cache_misses}")
+
+    if args.require_requests and compile_requests <= 0:
+        print("sccache did not observe compiler requests", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.ci/print_sccache_stats.py
+++ b/.ci/print_sccache_stats.py
@@ -30,13 +30,15 @@ def count_bucket(stats, name):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--require-requests", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
     args = parser.parse_args()
 
     if shutil.which("sccache") is None:
         print("sccache is not in PATH", file=sys.stderr)
         return 1 if args.require_requests else 0
 
-    subprocess.run(["sccache", "--show-stats"], check=False)
+    if args.verbose:
+        subprocess.run(["sccache", "--show-stats"], check=False)
 
     stats_json = subprocess.check_output(
         ["sccache", "--show-stats", "--stats-format=json"],

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -224,7 +224,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
                 fi
             fi
             cd "$EVMONE_DIR"
-            "$WORKSPACE_ROOT/.ci/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TARGET"
+            "$SCRIPT_DIR/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TARGET"
             EVMONE_STATETEST_BIN="$PWD/build/bin/evmone-statetest"
             cd "$WORKSPACE_ROOT"
 
@@ -325,7 +325,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             cp ../tools/check_performance_regression.py ./
 
             if [ ! -f "build/bin/evmone-bench" ]; then
-                "$WORKSPACE_ROOT/.ci/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+                "$SCRIPT_DIR/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE=Release
             fi
 
             BASELINE_CACHE=${BENCHMARK_BASELINE_CACHE:-}

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -21,6 +21,16 @@
 
 set -e
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+print_sccache_stats() {
+    if [ "${DTVM_CI_USE_SCCACHE:-0}" = "1" ] && command -v sccache >/dev/null 2>&1; then
+        python3 "$SCRIPT_DIR/print_sccache_stats.py" || true
+    fi
+}
+
+trap print_sccache_stats EXIT
+
 # Convert INPUT_FORMAT to lowercase for case-insensitive comparison
 INPUT_FORMAT=${INPUT_FORMAT,,}
 
@@ -129,7 +139,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
     else
         rm -rf build
     fi
-    .ci/cmake_ci_build.sh build -- $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
+    "$SCRIPT_DIR/cmake_ci_build.sh" build -- $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
     if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
         continue
     fi
@@ -214,8 +224,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
                 fi
             fi
             cd "$EVMONE_DIR"
-            cmake -S . -B build -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TARGET"
-            cmake --build build --parallel 16
+            "$WORKSPACE_ROOT/.ci/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TARGET"
             EVMONE_STATETEST_BIN="$PWD/build/bin/evmone-statetest"
             cd "$WORKSPACE_ROOT"
 
@@ -316,8 +325,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             cp ../tools/check_performance_regression.py ./
 
             if [ ! -f "build/bin/evmone-bench" ]; then
-                cmake -S . -B build -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE=Release
-                cmake --build build --parallel -j 16
+                "$WORKSPACE_ROOT/.ci/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE=Release
             fi
 
             BASELINE_CACHE=${BENCHMARK_BASELINE_CACHE:-}

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -114,14 +114,25 @@ export PATH=$PATH:$PWD/build
 CMAKE_OPTIONS_ORIGIN="$CMAKE_OPTIONS"
 
 if [[ ${INPUT_FORMAT} == "evm" ]]; then
-    ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm
-    ./tools/solc_batch_compile.sh
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        echo "+ ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm"
+        echo "+ ./tools/solc_batch_compile.sh"
+    else
+        ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm
+        ./tools/solc_batch_compile.sh
+    fi
 fi
 
 for STACK_TYPE in ${STACK_TYPES[@]}; do
-    rm -rf build
-    cmake -S . -B build $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
-    cmake --build build -j 16
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        echo "+ rm -rf build"
+    else
+        rm -rf build
+    fi
+    .ci/cmake_ci_build.sh build -- $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        continue
+    fi
 
     case $TestSuite in
         "microsuite")

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -25,6 +25,9 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 print_sccache_stats() {
     if [ "${DTVM_CI_USE_SCCACHE:-0}" = "1" ] && command -v sccache >/dev/null 2>&1; then
+        if [ -n "${1:-}" ]; then
+            echo "sccache stats checkpoint: $1"
+        fi
         python3 "$SCRIPT_DIR/print_sccache_stats.py" || true
     fi
 }
@@ -140,6 +143,9 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
         rm -rf build
     fi
     "$SCRIPT_DIR/cmake_ci_build.sh" build -- $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
+    if [[ $TestSuite == "benchmarksuite" ]]; then
+        print_sccache_stats "after DTVM build"
+    fi
     if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
         continue
     fi
@@ -327,6 +333,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             if [ ! -f "build/bin/evmone-bench" ]; then
                 "$SCRIPT_DIR/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE=Release
             fi
+            print_sccache_stats "before benchmarks"
 
             BASELINE_CACHE=${BENCHMARK_BASELINE_CACHE:-}
 

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -69,6 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: dtvmdev1/dtvm-dev-x64:main
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: dtvm-ci-sccache-v1
+      SCCACHE_BASEDIRS: ${{ github.workspace }}
+      DTVM_CI_USE_NINJA: "1"
+      DTVM_CI_USE_SCCACHE: "1"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -82,12 +88,24 @@ jobs:
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
           export LLVM_SYS_150_PREFIX=/opt/llvm15
           export LLVM_DIR=$LLVM_SYS_150_PREFIX/lib/cmake/llvm
           export PATH=$LLVM_SYS_150_PREFIX/bin:$PATH
+          echo "DTVM_CI_USE_NINJA=$DTVM_CI_USE_NINJA"
+          echo "DTVM_CI_USE_SCCACHE=$DTVM_CI_USE_SCCACHE"
+          echo "SCCACHE_GHA_VERSION=$SCCACHE_GHA_VERSION"
+          echo "SCCACHE_BASEDIRS=$SCCACHE_BASEDIRS"
+          which sccache
+          sccache --version
+          cmake --version
+          ninja --version
+          cc --version | head -n 1
+          c++ --version | head -n 1
           export CMAKE_BUILD_TARGET=Release
           export ENABLE_ASAN=true
           export RUN_MODE=multipass
@@ -99,6 +117,45 @@ jobs:
           export ENABLE_GAS_METER=true
 
           bash .ci/run_test_suite.sh
+      - name: Print sccache stats
+        if: always()
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            echo "sccache is not in PATH"
+            exit 1
+          fi
+          sccache --show-stats
+          sccache --show-stats --stats-format=json > /tmp/sccache-stats.json
+          python3 - <<'PY'
+          import json
+          import numbers
+          import sys
+
+          with open("/tmp/sccache-stats.json", encoding="utf-8") as f:
+              data = json.load(f)
+
+          stats = data.get("stats", {})
+          compile_requests = int(stats.get("compile_requests") or 0)
+
+          def sum_numbers(value):
+              if isinstance(value, bool):
+                  return 0
+              if isinstance(value, numbers.Number):
+                  return int(value)
+              if isinstance(value, dict):
+                  return sum(sum_numbers(item) for item in value.values())
+              if isinstance(value, list):
+                  return sum(sum_numbers(item) for item in value)
+              return 0
+
+          cache_hits = sum_numbers(stats.get("cache_hits", {}).get("counts", {}))
+          print(f"sccache compile_requests={compile_requests}")
+          print(f"sccache aggregate_cache_hits={cache_hits}")
+
+          if compile_requests <= 0:
+              print("sccache did not observe compiler requests", file=sys.stderr)
+              sys.exit(1)
+          PY
 
   build_test_evm_interpreter_x86_cli:
     name: Test DTVM-EVM interpreter with CLI on x86-64

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -288,6 +288,13 @@ jobs:
         with:
           path: /github/home/.fetchcontent
           key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
+      - name: Cache Hunter
+        uses: actions/cache@v4
+        with:
+          path: /github/home/.hunter
+          key: ${{ runner.os }}-hunter-evmone-v1-${{ hashFiles('.ci/run_test_suite.sh', '.github/workflows/dtvm_evm_test_x86.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-hunter-evmone-v1-
       - name: Code Format Check
         run: |
           ./tools/format.sh check
@@ -422,6 +429,14 @@ jobs:
         with:
           path: /github/home/.fetchcontent
           key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
+
+      - name: Cache Hunter
+        uses: actions/cache@v4
+        with:
+          path: /github/home/.hunter
+          key: ${{ runner.os }}-hunter-evmone-v1-${{ hashFiles('.ci/run_test_suite.sh', '.github/workflows/dtvm_evm_test_x86.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-hunter-evmone-v1-
 
       - name: Setup git safe directory
         run: |

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -25,6 +25,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_VERSION: dtvm-ci-sccache-v2-gcc11-llvm15-ninja
   SCCACHE_BASEDIRS: ${{ github.workspace }}
+  SCCACHE_IDLE_TIMEOUT: "0"
   DTVM_CI_USE_NINJA: "1"
   DTVM_CI_USE_SCCACHE: "1"
 

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -18,11 +18,15 @@ permissions:
 
 # Shared FetchContent cache root for all container jobs. The hook in
 # CMakeLists.txt (commit 96707a2 lines 8-18) picks this up as the base
-# dir for FetchContent populations. Each container job adds an
-# `actions/cache` step keyed on `hashFiles('third_party/AddDeps.cmake')`
-# to persist this dir across CI runs.
+# dir for FetchContent populations. The cache key includes the generator
+# namespace because CMake writes generator-specific FetchContent subbuilds.
 env:
   FETCHCONTENT_BASE_DIR: /github/home/.fetchcontent
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_VERSION: dtvm-ci-sccache-v2-gcc11-llvm15-ninja
+  SCCACHE_BASEDIRS: ${{ github.workspace }}
+  DTVM_CI_USE_NINJA: "1"
+  DTVM_CI_USE_SCCACHE: "1"
 
 jobs:
   build_test_evm_interpreter_x86_ctest:
@@ -39,10 +43,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Clone asmjit
         run: |
           git clone https://github.com/asmjit/asmjit.git
@@ -69,12 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: dtvmdev1/dtvm-dev-x64:main
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: dtvm-ci-sccache-v1
-      SCCACHE_BASEDIRS: ${{ github.workspace }}
-      DTVM_CI_USE_NINJA: "1"
-      DTVM_CI_USE_SCCACHE: "1"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
@@ -96,16 +96,6 @@ jobs:
           export LLVM_SYS_150_PREFIX=/opt/llvm15
           export LLVM_DIR=$LLVM_SYS_150_PREFIX/lib/cmake/llvm
           export PATH=$LLVM_SYS_150_PREFIX/bin:$PATH
-          echo "DTVM_CI_USE_NINJA=$DTVM_CI_USE_NINJA"
-          echo "DTVM_CI_USE_SCCACHE=$DTVM_CI_USE_SCCACHE"
-          echo "SCCACHE_GHA_VERSION=$SCCACHE_GHA_VERSION"
-          echo "SCCACHE_BASEDIRS=$SCCACHE_BASEDIRS"
-          which sccache
-          sccache --version
-          cmake --version
-          ninja --version
-          cc --version | head -n 1
-          c++ --version | head -n 1
           export CMAKE_BUILD_TARGET=Release
           export ENABLE_ASAN=true
           export RUN_MODE=multipass
@@ -117,45 +107,6 @@ jobs:
           export ENABLE_GAS_METER=true
 
           bash .ci/run_test_suite.sh
-      - name: Print sccache stats
-        if: always()
-        run: |
-          if ! command -v sccache >/dev/null 2>&1; then
-            echo "sccache is not in PATH"
-            exit 1
-          fi
-          sccache --show-stats
-          sccache --show-stats --stats-format=json > /tmp/sccache-stats.json
-          python3 - <<'PY'
-          import json
-          import numbers
-          import sys
-
-          with open("/tmp/sccache-stats.json", encoding="utf-8") as f:
-              data = json.load(f)
-
-          stats = data.get("stats", {})
-          compile_requests = int(stats.get("compile_requests") or 0)
-
-          def sum_numbers(value):
-              if isinstance(value, bool):
-                  return 0
-              if isinstance(value, numbers.Number):
-                  return int(value)
-              if isinstance(value, dict):
-                  return sum(sum_numbers(item) for item in value.values())
-              if isinstance(value, list):
-                  return sum(sum_numbers(item) for item in value)
-              return 0
-
-          cache_hits = sum_numbers(stats.get("cache_hits", {}).get("counts", {}))
-          print(f"sccache compile_requests={compile_requests}")
-          print(f"sccache aggregate_cache_hits={cache_hits}")
-
-          if compile_requests <= 0:
-              print("sccache did not observe compiler requests", file=sys.stderr)
-              sys.exit(1)
-          PY
 
   build_test_evm_interpreter_x86_cli:
     name: Test DTVM-EVM interpreter with CLI on x86-64
@@ -171,10 +122,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
@@ -218,10 +171,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
@@ -254,10 +209,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
@@ -291,10 +248,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
@@ -328,10 +287,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         env:
           LLVM_SYS_150_PREFIX: /opt/llvm15
@@ -363,7 +324,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Cache Hunter
         uses: actions/cache@v4
         with:
@@ -374,6 +335,8 @@ jobs:
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         env:
           LLVM_SYS_150_PREFIX: /opt/llvm15
@@ -409,10 +372,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
@@ -456,7 +421,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
 
       - name: Setup git safe directory
         run: |
@@ -466,6 +431,8 @@ jobs:
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       # Cache the BUILT baseline libdtvmapi.so (a deterministic function of
       # base.sha), not the bench output JSON (a function of source + host +
@@ -492,6 +459,9 @@ jobs:
           git checkout ${{ github.base_ref }}
 
           cmake -S . -B build \
+            -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
             -DCMAKE_BUILD_TYPE=Release \
             -DZEN_ENABLE_SINGLEPASS_JIT=OFF \
             -DZEN_ENABLE_MULTIPASS_JIT=ON \

--- a/.github/workflows/dtvm_wasm_test_x86.yml
+++ b/.github/workflows/dtvm_wasm_test_x86.yml
@@ -18,11 +18,15 @@ permissions:
 
 # Shared FetchContent cache root for all container jobs. The hook in
 # CMakeLists.txt (commit 96707a2 lines 8-18) picks this up as the base
-# dir for FetchContent populations. Each container job adds an
-# `actions/cache` step keyed on `hashFiles('third_party/AddDeps.cmake')`
-# to persist this dir across CI runs.
+# dir for FetchContent populations. The cache key includes the generator
+# namespace because CMake writes generator-specific FetchContent subbuilds.
 env:
   FETCHCONTENT_BASE_DIR: /github/home/.fetchcontent
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_GHA_VERSION: dtvm-ci-sccache-v2-gcc11-llvm15-ninja
+  SCCACHE_BASEDIRS: ${{ github.workspace }}
+  DTVM_CI_USE_NINJA: "1"
+  DTVM_CI_USE_SCCACHE: "1"
 
 jobs:
   build_test_interp_on_x86:
@@ -39,10 +43,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Test Git clone
         run: |
           git clone https://github.com/asmjit/asmjit.git
@@ -86,10 +92,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Test Git clone
         run: |
           git clone https://github.com/asmjit/asmjit.git
@@ -133,10 +141,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Test Git clone
         run: |
           git clone https://github.com/asmjit/asmjit.git
@@ -180,10 +190,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v2-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Test Git clone
         run: |
           git clone https://github.com/asmjit/asmjit.git
@@ -202,7 +214,16 @@ jobs:
           git apply ../spec.patch
           cd $CUR_PROJECT
 
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DZEN_ENABLE_DWASM=ON -DZEN_ENABLE_SINGLEPASS_JIT=ON -DZEN_ENABLE_MULTIPASS_JIT=ON -DZEN_ENABLE_CHECKED_ARITHMETIC=ON -DZEN_ENABLE_CPU_EXCEPTION=OFF -DZEN_ENABLE_EVMABI_TEST=ON -DZEN_ENABLE_BUILTIN_LIBC=OFF -DZEN_ENABLE_BUILTIN_ENV=OFF
-          cmake --build build -j7
+          DTVM_CI_BUILD_JOBS=7 .ci/cmake_ci_build.sh build -- \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DZEN_ENABLE_DWASM=ON \
+            -DZEN_ENABLE_SINGLEPASS_JIT=ON \
+            -DZEN_ENABLE_MULTIPASS_JIT=ON \
+            -DZEN_ENABLE_CHECKED_ARITHMETIC=ON \
+            -DZEN_ENABLE_CPU_EXCEPTION=OFF \
+            -DZEN_ENABLE_EVMABI_TEST=ON \
+            -DZEN_ENABLE_BUILTIN_LIBC=OFF \
+            -DZEN_ENABLE_BUILTIN_ENV=OFF
+          python3 .ci/print_sccache_stats.py || true
           # use dtvm to test evm abi wasm files
           # ./build/dtvm -m 2 -f call counter.wasm

--- a/.github/workflows/dtvm_wasm_test_x86.yml
+++ b/.github/workflows/dtvm_wasm_test_x86.yml
@@ -25,6 +25,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   SCCACHE_GHA_VERSION: dtvm-ci-sccache-v2-gcc11-llvm15-ninja
   SCCACHE_BASEDIRS: ${{ github.workspace }}
+  SCCACHE_IDLE_TIMEOUT: "0"
   DTVM_CI_USE_NINJA: "1"
   DTVM_CI_USE_SCCACHE: "1"
 


### PR DESCRIPTION
## Why
CI wall time is dominated by C++ compilation rather than dependency downloads. After the canary jobs showed stable Ninja+sccache behavior and green EVM/WASM checks, this PR rolls the setup out across the x86 test workflows and keeps perf-job sccache stats alive through long benchmark phases.

## What
- Enable Ninja and sccache globally for the EVM/WASM test workflows.
- Route `run_test_suite.sh` CMake builds through the shared `.ci/cmake_ci_build.sh` helper, including evmone sub-builds.
- Keep the perf baseline checkout path self-contained by passing Ninja and sccache launcher flags directly, because that step checks out base `main`.
- Move FetchContent caches to a Ninja-specific key namespace.
- Cache Hunter's `/github/home/.hunter` package directory for evmone unit/statetest/perf jobs.
- Keep sccache server stats alive across long perf benchmarks with `SCCACHE_IDLE_TIMEOUT=0`.
- Add compact sccache stats printing, including perf-only checkpoints after the DTVM build and before benchmark execution.

## Local verification
- `bash -n .ci/cmake_ci_build.sh .ci/run_test_suite.sh`
- `python3 -m py_compile .ci/print_sccache_stats.py`
- Ruby YAML parse for both edited workflows
- `git diff --check`
- `PATH=/opt/llvm15/bin:$PATH ./tools/format.sh check`
- Representative `DTVM_CI_DRY_RUN=1` command expansion shows `-G Ninja` and `-DCMAKE_*_COMPILER_LAUNCHER=sccache` when enabled, and preserves the default non-Ninja path when disabled.

## CI validation
Latest `pull_request` runs for commit `98950bf8876eb44228d38dfc9a4cde4daad26e7b` are green:

- EVM workflow: https://github.com/abmcar/DTVM/actions/runs/25953064353
- WASM workflow: https://github.com/abmcar/DTVM/actions/runs/25953064357
- Commit lint: https://github.com/abmcar/DTVM/actions/runs/25953064358

Observed warm-cache job times from the latest successful checks:

| Job | Time |
|---|---:|
| WASM interpreter | 2m12s |
| WASM singlepass | 4m02s |
| WASM multipass | 3m35s |
| WASM evmabi mock CLI | 2m26s |
| EVM interpreter ctest | 3m27s |
| EVM interpreter CLI | 3m11s |
| EVM multipass release ctest | 4m32s |
| EVM multipass debug | 4m34s |
| EVM multipass gas register | 4m38s |
| EVM evmtestsuite gas register ctest | 4m38s |
| EVM JIT fallback ctest | 4m49s |
| EVM evmone unit tests | 6m01s |
| EVM evmone statetests | 6m48s |
| Perf interpreter | 28m21s |
| Perf multipass | 32m21s |

Perf sccache stats are now retained through the long benchmark phase:

| Perf job | After DTVM build | Before benchmarks | Final stats |
|---|---:|---:|---:|
| interpreter | 122 req / 122 hits / 0 misses | 255 req / 202 hits / 53 misses | 255 req / 202 hits / 53 misses |
| multipass | 122 req / 106 hits / 16 misses | 255 req / 239 hits / 16 misses | 255 req / 239 hits / 16 misses |

This confirms the previous `compile_requests=0` in perf jobs was stats lifecycle/idle-timeout related, not a missing CMake compiler launcher. Perf jobs remain benchmark-dominated because each job still runs baseline and current benchmarks on the same runner.

