### PR TITLE
ci: speed up evmone perf regression

### DIFF
--- a/.ci/cmake_ci_build.sh
+++ b/.ci/cmake_ci_build.sh
@@ -19,6 +19,7 @@ USE_NINJA=${DTVM_CI_USE_NINJA:-0}
 USE_SCCACHE=${DTVM_CI_USE_SCCACHE:-0}
 DRY_RUN=${DTVM_CI_DRY_RUN:-0}
 BUILD_JOBS=${DTVM_CI_BUILD_JOBS:-16}
+BUILD_TARGETS=${DTVM_CI_BUILD_TARGETS:-}
 
 GENERATOR_ARGS=()
 if [ "$USE_NINJA" = "1" ]; then
@@ -41,7 +42,13 @@ CONFIGURE_CMD=(
     "${LAUNCHER_ARGS[@]}"
     "$@"
 )
-BUILD_CMD=(cmake --build "$BUILD_DIR" -j "$BUILD_JOBS")
+BUILD_CMD=(cmake --build "$BUILD_DIR")
+if [ -n "$BUILD_TARGETS" ]; then
+    for TARGET in $BUILD_TARGETS; do
+        BUILD_CMD+=(--target "$TARGET")
+    done
+fi
+BUILD_CMD+=(-j "$BUILD_JOBS")
 
 echo "DTVM CI CMake source dir: ${SOURCE_DIR}"
 echo "DTVM CI CMake generator: ${USE_NINJA}"

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -299,10 +299,26 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             ;;
         "benchmarksuite")
             # Clone evmone and run performance regression check
-            EVMONE_DIR="evmone"
-            if [ ! -d "$EVMONE_DIR" ]; then
-                git clone --depth 1 --recurse-submodules -b for_test https://github.com/DTVMStack/evmone.git $EVMONE_DIR
+            EVMONE_DIR=${EVMONE_DIR:-evmone}
+            EVMONE_REPO=${EVMONE_REPO:-https://github.com/DTVMStack/evmone.git}
+            EVMONE_REF=${EVMONE_REF:-for_test}
+            EVMONE_COMMIT=${EVMONE_COMMIT:-}
+
+            if [ -z "$EVMONE_COMMIT" ]; then
+                EVMONE_COMMIT=$(git ls-remote "$EVMONE_REPO" "refs/heads/$EVMONE_REF" | awk '{print $1}')
             fi
+            if [ -z "$EVMONE_COMMIT" ]; then
+                echo "Unable to resolve $EVMONE_REPO refs/heads/$EVMONE_REF"
+                exit 1
+            fi
+
+            if [ ! -d "$EVMONE_DIR/.git" ]; then
+                rm -rf "$EVMONE_DIR"
+                git clone --depth 1 --recurse-submodules -b "$EVMONE_REF" "$EVMONE_REPO" "$EVMONE_DIR"
+            fi
+            git -C "$EVMONE_DIR" fetch --depth 1 origin "$EVMONE_REF"
+            git -C "$EVMONE_DIR" checkout --detach "$EVMONE_COMMIT"
+            git -C "$EVMONE_DIR" submodule update --init --recursive
 
             BENCHMARK_THRESHOLD=${BENCHMARK_THRESHOLD:-0.15}
             BENCHMARK_MODE=${BENCHMARK_MODE:-multipass}
@@ -325,7 +341,10 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             cp ../tools/check_performance_regression.py ./
 
             if [ ! -f "build/bin/evmone-bench" ]; then
-                "$SCRIPT_DIR/cmake_ci_build.sh" build -- -DEVMONE_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+                DTVM_CI_BUILD_TARGETS=evmone-bench \
+                    "$SCRIPT_DIR/cmake_ci_build.sh" build -- \
+                    -DEVMONE_TESTING=ON \
+                    -DCMAKE_BUILD_TYPE=Release
             fi
 
             BASELINE_CACHE=${BENCHMARK_BASELINE_CACHE:-}

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -325,6 +325,7 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             BENCHMARK_SUMMARY_FILE=${BENCHMARK_SUMMARY_FILE:-/tmp/perf_summary.md}
             BENCHMARK_REPETITIONS=${BENCHMARK_REPETITIONS:-3}
             BENCHMARK_MIN_TIME=${BENCHMARK_MIN_TIME:-""}
+            BENCHMARK_JOBS=${BENCHMARK_JOBS:-1}
 
             PERF_ARGS=""
             if [ -n "$BENCHMARK_REPETITIONS" ]; then
@@ -332,6 +333,9 @@ for STACK_TYPE in ${STACK_TYPES[@]}; do
             fi
             if [ -n "$BENCHMARK_MIN_TIME" ]; then
                 PERF_ARGS="$PERF_ARGS --benchmark-min-time $BENCHMARK_MIN_TIME"
+            fi
+            if [ -n "$BENCHMARK_JOBS" ]; then
+                PERF_ARGS="$PERF_ARGS --benchmark-jobs $BENCHMARK_JOBS"
             fi
 
             cp build/lib/* $EVMONE_DIR/

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -546,7 +546,7 @@ jobs:
           export BENCHMARK_BASELINE_LIB=/tmp/baseline_lib
           export BENCHMARK_SUMMARY_FILE=/tmp/perf_summary_${{ matrix.mode }}.md
           export BENCHMARK_REPETITIONS=5
-          export BENCHMARK_JOBS=4
+          export BENCHMARK_JOBS=3
           export EVMONE_COMMIT=${{ steps.evmone.outputs.commit }}
 
           bash .ci/run_test_suite.sh

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -546,6 +546,7 @@ jobs:
           export BENCHMARK_BASELINE_LIB=/tmp/baseline_lib
           export BENCHMARK_SUMMARY_FILE=/tmp/perf_summary_${{ matrix.mode }}.md
           export BENCHMARK_REPETITIONS=5
+          export BENCHMARK_JOBS=2
           export EVMONE_COMMIT=${{ steps.evmone.outputs.commit }}
 
           bash .ci/run_test_suite.sh

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -546,7 +546,7 @@ jobs:
           export BENCHMARK_BASELINE_LIB=/tmp/baseline_lib
           export BENCHMARK_SUMMARY_FILE=/tmp/perf_summary_${{ matrix.mode }}.md
           export BENCHMARK_REPETITIONS=5
-          export BENCHMARK_JOBS=2
+          export BENCHMARK_JOBS=4
           export EVMONE_COMMIT=${{ steps.evmone.outputs.commit }}
 
           bash .ci/run_test_suite.sh

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -16,6 +16,10 @@ on:
 permissions:
     contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Shared FetchContent cache root for all container jobs. The hook in
 # CMakeLists.txt (commit 96707a2 lines 8-18) picks this up as the base
 # dir for FetchContent populations. The cache key includes the generator
@@ -27,6 +31,9 @@ env:
   SCCACHE_BASEDIRS: ${{ github.workspace }}
   DTVM_CI_USE_NINJA: "1"
   DTVM_CI_USE_SCCACHE: "1"
+  EVMONE_REPO: https://github.com/DTVMStack/evmone.git
+  EVMONE_REF: for_test
+  EVMONE_BENCH_CACHE_VERSION: v1
 
 jobs:
   build_test_evm_interpreter_x86_ctest:
@@ -438,6 +445,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hunter-evmone-v1-
 
+      - name: Resolve evmone benchmark commit
+        id: evmone
+        run: |
+          EVMONE_COMMIT=$(git ls-remote "$EVMONE_REPO" "refs/heads/$EVMONE_REF" | awk '{print $1}')
+          if [ -z "$EVMONE_COMMIT" ]; then
+            echo "Unable to resolve $EVMONE_REPO refs/heads/$EVMONE_REF" >&2
+            exit 1
+          fi
+          echo "commit=$EVMONE_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "Resolved evmone $EVMONE_REF to $EVMONE_COMMIT"
+
+      - name: Cache evmone-bench
+        uses: actions/cache@v4
+        with:
+          path: evmone
+          key: ${{ runner.os }}-evmone-bench-${{ env.EVMONE_BENCH_CACHE_VERSION }}-${{ steps.evmone.outputs.commit }}-${{ hashFiles('.ci/run_test_suite.sh', '.github/workflows/dtvm_evm_test_x86.yml') }}
+
       - name: Setup git safe directory
         run: |
           echo "Configuring git safe directory: ${{ github.workspace }}"
@@ -508,7 +532,7 @@ jobs:
           export LLVM_DIR=$LLVM_SYS_150_PREFIX/lib/cmake/llvm
           export PATH=$LLVM_SYS_150_PREFIX/bin:$PATH
 
-          rm -rf build evmone
+          rm -rf build
 
           export CMAKE_BUILD_TARGET=Release
           export ENABLE_ASAN=false
@@ -522,9 +546,15 @@ jobs:
           export BENCHMARK_BASELINE_LIB=/tmp/baseline_lib
           export BENCHMARK_SUMMARY_FILE=/tmp/perf_summary_${{ matrix.mode }}.md
           export BENCHMARK_REPETITIONS=5
+          export EVMONE_COMMIT=${{ steps.evmone.outputs.commit }}
 
           bash .ci/run_test_suite.sh
         continue-on-error: true
+
+      - name: Clean evmone cache inputs
+        if: always()
+        run: |
+          rm -f evmone/libdtvmapi.so evmone/libdtvmapi.so.* evmone/check_performance_regression.py
 
       - name: Write Performance Summary
         if: always()

--- a/tools/check_performance_regression.py
+++ b/tools/check_performance_regression.py
@@ -21,10 +21,12 @@ Exit codes:
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
+from collections import Counter
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
@@ -37,33 +39,43 @@ class BenchmarkResult:
     iterations: int
 
 
-def run_benchmark(
-    lib_path: str,
-    mode: str,
+def benchmark_env(lib_path: str, mode: str) -> Dict[str, str]:
+    return {**os.environ, "EVMONE_EXTERNAL_OPTIONS": f"{lib_path},mode={mode}"}
+
+
+def available_cpus() -> List[int]:
+    if hasattr(os, "sched_getaffinity"):
+        return sorted(os.sched_getaffinity(0))
+    cpu_count = os.cpu_count() or 1
+    return list(range(cpu_count))
+
+
+def split_benchmark_args(extra_args: Optional[List[str]]) -> Tuple[str, List[str]]:
+    benchmark_filter = "external/total/*"
+    remaining_args: List[str] = []
+
+    for arg in extra_args or []:
+        if arg.startswith("--benchmark_filter="):
+            benchmark_filter = arg.split("=", 1)[1]
+        else:
+            remaining_args.append(arg)
+
+    return benchmark_filter, remaining_args
+
+
+def build_benchmark_cmd(
     benchmark_dir: str,
-    extra_args: Optional[List[str]] = None,
-    repetitions: int = 3,
-    benchmark_min_time: Optional[str] = None,
-) -> List[BenchmarkResult]:
-    """Run benchmark and parse JSON output.
-
-    Uses --benchmark_out to write JSON results to a temporary file so that
-    the human-readable benchmark progress streams to stdout/stderr in real
-    time (important for CI visibility).
-
-    When *repetitions* > 1, each benchmark runs N times and only the
-    median aggregate is kept, significantly reducing noise from ASLR and
-    shared-runner contention.
-    """
-    env = {"EVMONE_EXTERNAL_OPTIONS": f"{lib_path},mode={mode}"}
-
-    fd, json_out_path = tempfile.mkstemp(suffix=".json")
-    os.close(fd)
-
+    json_out_path: str,
+    benchmark_filter: str,
+    repetitions: int,
+    benchmark_min_time: Optional[str],
+    extra_args: List[str],
+    cpu: Optional[int],
+) -> List[str]:
     cmd: List[str] = []
 
-    if shutil.which("taskset"):
-        cmd.extend(["taskset", "-c", "0"])
+    if cpu is not None and shutil.which("taskset"):
+        cmd.extend(["taskset", "-c", str(cpu)])
 
     cmd.extend([
         "./build/bin/evmone-bench",
@@ -80,39 +92,242 @@ def run_benchmark(
     if benchmark_min_time:
         cmd.append(f"--benchmark_min_time={benchmark_min_time}")
 
-    if extra_args:
-        cmd.extend(extra_args)
+    cmd.extend(extra_args)
+    cmd.append(f"--benchmark_filter={benchmark_filter}")
+    return cmd
 
-    if not any(arg.startswith("--benchmark_filter") for arg in cmd):
-        cmd.append("--benchmark_filter=external/total/*")
 
-    print(f"Running: {' '.join(cmd)}")
-    print(f"Environment: EVMONE_EXTERNAL_OPTIONS={env['EVMONE_EXTERNAL_OPTIONS']}")
+def list_benchmark_names(
+    lib_path: str,
+    mode: str,
+    benchmark_dir: str,
+    benchmark_filter: str,
+    extra_args: List[str],
+) -> List[str]:
+    cmd = [
+        "./build/bin/evmone-bench",
+        benchmark_dir,
+        "--benchmark_list_tests",
+        f"--benchmark_filter={benchmark_filter}",
+    ]
+    cmd.extend(extra_args)
+
+    print(f"Listing benchmarks: {' '.join(cmd)}")
     sys.stdout.flush()
 
     result = subprocess.run(
         cmd,
-        env={**subprocess.os.environ, **env},
+        env=benchmark_env(lib_path, mode),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
-
     if result.returncode != 0:
-        print(f"Benchmark execution failed with code {result.returncode}")
-        try:
-            os.unlink(json_out_path)
-        except OSError:
-            pass
+        print(result.stdout, end="")
+        print(f"Benchmark listing failed with code {result.returncode}")
         sys.exit(2)
 
+    names: List[str] = []
+    for line in result.stdout.splitlines():
+        name = line.strip()
+        if not name or any(ch.isspace() for ch in name):
+            continue
+        names.append(name)
+
+    if not names:
+        print(f"::error::No benchmarks matched filter: {benchmark_filter}")
+        sys.exit(2)
+
+    return names
+
+
+def exact_filter(names: List[str]) -> str:
+    return "^(" + "|".join(re.escape(name) for name in names) + ")$"
+
+
+def parse_benchmark_json_file(json_out_path: str) -> List[BenchmarkResult]:
+    with open(json_out_path, "r") as f:
+        json_data = f.read()
+    return parse_benchmark_json(json_data)
+
+
+def run_benchmark_shard(
+    lib_path: str,
+    mode: str,
+    benchmark_dir: str,
+    benchmark_filter: str,
+    extra_args: List[str],
+    repetitions: int,
+    benchmark_min_time: Optional[str],
+    cpu: Optional[int],
+) -> List[BenchmarkResult]:
+    fd, json_out_path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+
     try:
-        with open(json_out_path, "r") as f:
-            json_data = f.read()
+        cmd = build_benchmark_cmd(
+            benchmark_dir,
+            json_out_path,
+            benchmark_filter,
+            repetitions,
+            benchmark_min_time,
+            extra_args,
+            cpu,
+        )
+
+        print(f"Running: {' '.join(cmd)}")
+        print(f"Environment: EVMONE_EXTERNAL_OPTIONS={lib_path},mode={mode}")
+        sys.stdout.flush()
+
+        result = subprocess.run(cmd, env=benchmark_env(lib_path, mode))
+
+        if result.returncode != 0:
+            print(f"Benchmark execution failed with code {result.returncode}")
+            sys.exit(2)
+
+        return parse_benchmark_json_file(json_out_path)
     finally:
         try:
             os.unlink(json_out_path)
         except OSError:
             pass
 
-    return parse_benchmark_json(json_data)
+
+def run_benchmark_parallel(
+    lib_path: str,
+    mode: str,
+    benchmark_dir: str,
+    extra_args: Optional[List[str]],
+    repetitions: int,
+    benchmark_min_time: Optional[str],
+    benchmark_jobs: int,
+) -> List[BenchmarkResult]:
+    benchmark_filter, remaining_args = split_benchmark_args(extra_args)
+
+    if benchmark_jobs <= 1:
+        cpus = available_cpus()
+        cpu = cpus[0] if cpus else None
+        return run_benchmark_shard(
+            lib_path,
+            mode,
+            benchmark_dir,
+            benchmark_filter,
+            remaining_args,
+            repetitions,
+            benchmark_min_time,
+            cpu,
+        )
+
+    names = list_benchmark_names(
+        lib_path, mode, benchmark_dir, benchmark_filter, remaining_args
+    )
+    cpus = available_cpus()
+    jobs = min(benchmark_jobs, len(names), len(cpus) if cpus else benchmark_jobs)
+
+    if jobs < benchmark_jobs:
+        print(f"::notice::Reduced benchmark jobs from {benchmark_jobs} to {jobs}")
+
+    shards = [names[i::jobs] for i in range(jobs)]
+    temp_paths: List[str] = []
+    processes: List[subprocess.Popen] = []
+
+    try:
+        for index, shard_names in enumerate(shards):
+            fd, json_out_path = tempfile.mkstemp(suffix=".json")
+            os.close(fd)
+            temp_paths.append(json_out_path)
+
+            cpu = cpus[index % len(cpus)] if cpus else None
+            cmd = build_benchmark_cmd(
+                benchmark_dir,
+                json_out_path,
+                exact_filter(shard_names),
+                repetitions,
+                benchmark_min_time,
+                remaining_args,
+                cpu,
+            )
+
+            cpu_msg = f" on CPU {cpu}" if cpu is not None else ""
+            print(
+                f"Starting benchmark shard {index + 1}/{jobs}"
+                f" ({len(shard_names)} benchmarks){cpu_msg}: {' '.join(cmd)}"
+            )
+            sys.stdout.flush()
+
+            processes.append(
+                subprocess.Popen(cmd, env=benchmark_env(lib_path, mode))
+            )
+
+        failures = []
+        for index, process in enumerate(processes):
+            return_code = process.wait()
+            if return_code != 0:
+                failures.append((index + 1, return_code))
+
+        if failures:
+            for shard, return_code in failures:
+                print(
+                    f"Benchmark shard {shard} failed with code {return_code}"
+                )
+            sys.exit(2)
+
+        results: List[BenchmarkResult] = []
+        for json_out_path in temp_paths:
+            results.extend(parse_benchmark_json_file(json_out_path))
+
+        name_counts = Counter(result.name for result in results)
+        duplicate_names = sorted(
+            name for name, count in name_counts.items() if count > 1
+        )
+        if duplicate_names:
+            print(f"::error::Duplicate benchmark results: {duplicate_names}")
+            sys.exit(2)
+
+        return sorted(results, key=lambda result: result.name)
+    finally:
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+        for json_out_path in temp_paths:
+            try:
+                os.unlink(json_out_path)
+            except OSError:
+                pass
+
+
+def run_benchmark(
+    lib_path: str,
+    mode: str,
+    benchmark_dir: str,
+    extra_args: Optional[List[str]] = None,
+    repetitions: int = 3,
+    benchmark_min_time: Optional[str] = None,
+    benchmark_jobs: int = 1,
+) -> List[BenchmarkResult]:
+    """Run benchmark and parse JSON output.
+
+    Uses --benchmark_out to write JSON results to a temporary file so that
+    the human-readable benchmark progress streams to stdout/stderr in real
+    time (important for CI visibility).
+
+    When *repetitions* > 1, each benchmark runs N times and only the
+    median aggregate is kept, significantly reducing noise from ASLR and
+    shared-runner contention.
+    """
+    if benchmark_jobs < 1:
+        print("::error::--benchmark-jobs must be >= 1")
+        sys.exit(2)
+
+    return run_benchmark_parallel(
+        lib_path,
+        mode,
+        benchmark_dir,
+        extra_args,
+        repetitions,
+        benchmark_min_time,
+        benchmark_jobs,
+    )
 
 
 def parse_benchmark_json(json_output: str) -> List[BenchmarkResult]:
@@ -483,6 +698,12 @@ Examples:
         default=None,
         help="Minimum execution time per benchmark (e.g., '1s' or '2.0'). Forwarded to evmone-bench.",
     )
+    parser.add_argument(
+        "--benchmark-jobs",
+        type=int,
+        default=1,
+        help="Run benchmark shards in parallel across CPUs (default: 1).",
+    )
 
     args = parser.parse_args()
 
@@ -502,6 +723,7 @@ Examples:
             extra_args=bench_extra,
             repetitions=args.benchmark_repetitions,
             benchmark_min_time=args.benchmark_min_time,
+            benchmark_jobs=args.benchmark_jobs,
         )
     except Exception as e:
         print(f"::error::Failed to run benchmarks: {e}")


### PR DESCRIPTION
## What
- Resolve the current `DTVMStack/evmone` `for_test` HEAD during the perf job and cache the resulting `evmone-bench` build by resolved commit SHA.
- Keep using the latest `for_test` commit; cache invalidates automatically when that branch moves.
- Cache the baseline `libdtvmapi.so` per perf mode and PR base SHA, so repeated perf runs do not rebuild the baseline library.
- Run evmone benchmarks in 3 shards inside each perf job, preserving the same benchmark list and `BENCHMARK_REPETITIONS=5`.
- Add PR concurrency so newer commits cancel older fork PR runs.

## Why
The perf regression job spent most of its wall time repeatedly rebuilding setup artifacts and then running baseline/current benchmark suites serially. This keeps the comparison semantics unchanged while reducing setup/build overhead and benchmark wall time. The final shard count favors lower false-positive risk over the absolute fastest interpreter run.

## Validation
- `bash -n .ci/run_test_suite.sh`
- `python3 -m py_compile tools/check_performance_regression.py`
- workflow YAML parsed with `yaml.safe_load`
- `git diff --check`
- PR CI passed on `abmcar/DTVM#19`

## CI timing
Compared with the warm-cache `ci/sccache-ninja-all` rebase run before benchmark sharding:
- interpreter perf: `28m14s` -> `12m11s`
- multipass perf: `33m50s` -> `15m50s`

A 4-shard run was faster (`10m33s` interpreter, `13m31s` multipass), but had 4 counted interpreter threshold exceedances. The final 3-shard #19 run passed both perf jobs with 194 benchmarks, 0 regressions, and counted interpreter noise at median `1.4%`, p95 `6.2%`, max `12.8%`.
