### PR TITLE
docs(other): record U256 add/sub/bitwise lowering rewrite (not cherry-pick) blockers

### DIFF
--- a/.ci/cmake_ci_build.sh
+++ b/.ci/cmake_ci_build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <build-dir> [--] [cmake configure args...]" >&2
+    exit 2
+fi
+
+BUILD_DIR=$1
+shift
+
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+
+USE_NINJA=${DTVM_CI_USE_NINJA:-0}
+USE_SCCACHE=${DTVM_CI_USE_SCCACHE:-0}
+DRY_RUN=${DTVM_CI_DRY_RUN:-0}
+BUILD_JOBS=${DTVM_CI_BUILD_JOBS:-16}
+
+GENERATOR_ARGS=()
+if [ "$USE_NINJA" = "1" ]; then
+    GENERATOR_ARGS=(-G Ninja)
+fi
+
+LAUNCHER_ARGS=()
+if [ "$USE_SCCACHE" = "1" ]; then
+    LAUNCHER_ARGS=(
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+    )
+fi
+
+CONFIGURE_CMD=(
+    cmake
+    -S .
+    -B "$BUILD_DIR"
+    "${GENERATOR_ARGS[@]}"
+    "${LAUNCHER_ARGS[@]}"
+    "$@"
+)
+BUILD_CMD=(cmake --build "$BUILD_DIR" -j "$BUILD_JOBS")
+
+echo "DTVM CI CMake generator: ${USE_NINJA}"
+echo "DTVM CI CMake sccache launcher: ${USE_SCCACHE}"
+
+printf '+'
+printf ' %q' "${CONFIGURE_CMD[@]}"
+printf '\n'
+
+if [ "$DRY_RUN" = "1" ]; then
+    printf '+'
+    printf ' %q' "${BUILD_CMD[@]}"
+    printf '\n'
+    exit 0
+fi
+
+if [ "$USE_SCCACHE" = "1" ] && ! command -v sccache >/dev/null 2>&1; then
+    echo "DTVM_CI_USE_SCCACHE=1 but sccache is not in PATH" >&2
+    exit 1
+fi
+
+"${CONFIGURE_CMD[@]}"
+
+printf '+'
+printf ' %q' "${BUILD_CMD[@]}"
+printf '\n'
+"${BUILD_CMD[@]}"

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -114,14 +114,25 @@ export PATH=$PATH:$PWD/build
 CMAKE_OPTIONS_ORIGIN="$CMAKE_OPTIONS"
 
 if [[ ${INPUT_FORMAT} == "evm" ]]; then
-    ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm
-    ./tools/solc_batch_compile.sh
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        echo "+ ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm"
+        echo "+ ./tools/solc_batch_compile.sh"
+    else
+        ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm
+        ./tools/solc_batch_compile.sh
+    fi
 fi
 
 for STACK_TYPE in ${STACK_TYPES[@]}; do
-    rm -rf build
-    cmake -S . -B build $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
-    cmake --build build -j 16
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        echo "+ rm -rf build"
+    else
+        rm -rf build
+    fi
+    .ci/cmake_ci_build.sh build -- $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        continue
+    fi
 
     case $TestSuite in
         "microsuite")

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -69,6 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: dtvmdev1/dtvm-dev-x64:main
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: dtvm-ci-sccache-v1
+      SCCACHE_BASEDIRS: ${{ github.workspace }}
+      DTVM_CI_USE_NINJA: "1"
+      DTVM_CI_USE_SCCACHE: "1"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -82,12 +88,24 @@ jobs:
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
           export LLVM_SYS_150_PREFIX=/opt/llvm15
           export LLVM_DIR=$LLVM_SYS_150_PREFIX/lib/cmake/llvm
           export PATH=$LLVM_SYS_150_PREFIX/bin:$PATH
+          echo "DTVM_CI_USE_NINJA=$DTVM_CI_USE_NINJA"
+          echo "DTVM_CI_USE_SCCACHE=$DTVM_CI_USE_SCCACHE"
+          echo "SCCACHE_GHA_VERSION=$SCCACHE_GHA_VERSION"
+          echo "SCCACHE_BASEDIRS=$SCCACHE_BASEDIRS"
+          which sccache
+          sccache --version
+          cmake --version
+          ninja --version
+          cc --version | head -n 1
+          c++ --version | head -n 1
           export CMAKE_BUILD_TARGET=Release
           export ENABLE_ASAN=true
           export RUN_MODE=multipass
@@ -99,6 +117,45 @@ jobs:
           export ENABLE_GAS_METER=true
 
           bash .ci/run_test_suite.sh
+      - name: Print sccache stats
+        if: always()
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            echo "sccache is not in PATH"
+            exit 1
+          fi
+          sccache --show-stats
+          sccache --show-stats --stats-format=json > /tmp/sccache-stats.json
+          python3 - <<'PY'
+          import json
+          import numbers
+          import sys
+
+          with open("/tmp/sccache-stats.json", encoding="utf-8") as f:
+              data = json.load(f)
+
+          stats = data.get("stats", {})
+          compile_requests = int(stats.get("compile_requests") or 0)
+
+          def sum_numbers(value):
+              if isinstance(value, bool):
+                  return 0
+              if isinstance(value, numbers.Number):
+                  return int(value)
+              if isinstance(value, dict):
+                  return sum(sum_numbers(item) for item in value.values())
+              if isinstance(value, list):
+                  return sum(sum_numbers(item) for item in value)
+              return 0
+
+          cache_hits = sum_numbers(stats.get("cache_hits", {}).get("counts", {}))
+          print(f"sccache compile_requests={compile_requests}")
+          print(f"sccache aggregate_cache_hits={cache_hits}")
+
+          if compile_requests <= 0:
+              print("sccache did not observe compiler requests", file=sys.stderr)
+              sys.exit(1)
+          PY
 
   build_test_evm_interpreter_x86_cli:
     name: Test DTVM-EVM interpreter with CLI on x86-64

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check

--- a/docs/changes/2026-05-16-u256-track-b-audit/README.md
+++ b/docs/changes/2026-05-16-u256-track-b-audit/README.md
@@ -1,0 +1,147 @@
+# Track B Cherry-Pick Feasibility Audit (read-only)
+
+**Status**: Implemented (audit-only, no code change)
+**Tier**: Light (doc-only)
+**Created**: 2026-05-16
+**Branch**: docs/u256-track-b-cherry-pick-audit
+
+## Overview
+
+13 个 dangling commits 在 reflog 中保存了 2026-04 的 "Track B" 评估工作 (`evm_u256_bitwise` AND/OR/XOR 并行 lowering、`evm_u256_shl/shr/sar` SHLD/SHRD lowering、`MultiWordAdd/Sub` atomic、`u256-xor-self` synthesized rule)。`docs/research/directions/u256-strength-reduction/analysis/2026-05-16-next-steps-direction-scan.md` §2 N7 把这条路径标为 Tier 1 conditional — audit 是 Tier 1，cherry-pick 后是否升 Tier 取决于实测 delta。
+
+本审计**只读**地评估"cherry-pick 到当前 main 的可行性"。**Verdict: MAJOR — 不是 cherry-pick，是 re-implementation 任务**。
+
+## Motivation
+
+verified-opps §1.C 报告 Phase 1 (bitwise) +3.421% geomean、Phase 2 (shifts) +1.538% additional、blake2b_huff +13%、sha1_shifts +8.5%（2026-04 baseline window 实测）。这是当前 U256 强度削减方向**最大杠杆点**：
+
+- 若 cherry-pick 可行 → 实测 ≥3% geomean → 方向自然收尾，转 next direction
+- 若 不可行 → 沿 N1/N2/C-ISZERO/N5/N6 走完，6-8 周内拿到 ≥1 个 ≥1% per-bench 信号否则 kill direction (per §5 收尾标准)
+
+因此 audit 结论直接 gate 下一阶段决策。
+
+## Audit Findings
+
+### §1. 13 commits 拓扑
+
+**不是单一线性 chain，是 3 条独立 chain**：
+
+```
+Chain A (9 commits, base 856a638):
+  856a638 → a34d460 → 3319fdf → 9e00169 → ee0c487 → 54d0aae →
+            8dbe3f3 → 19daebe → 69628db → 91174d4
+
+Chain B (1 commit, base 998d9c6, completely independent of A/C):
+  998d9c6 → 5738f6f
+
+Chain C (3 commits, base 9e7b2b6, independent of A/B):
+  9e7b2b6 → abfa2a2 → 34656d5
+  (加 250cb7f 经由 883a6ac → 60cdf0f → 49f2ba8 → 91174d4 接到 Chain A 尾)
+```
+
+原 `2026-05-16-next-steps-direction-scan.md` §2 N7 列表中 `8dbe3f3 / 91174d4 / 69628db` 三 commit 顺序错乱 — 真实 chain 序为 `54d0aae→8dbe3f3→19daebe→69628db→91174d4`。
+
+### §2. base commit 与 origin/main 距离
+
+| Chain | Base | `rev-list --count base..origin/main` | 是否是 origin/main 祖先 |
+|-------|------|--------------------------------------|--------------------------|
+| A | `856a638` | 35 | NO |
+| B | `998d9c6` | 24 | NO |
+| C | `883a6ac` / `9e7b2b6` | n/a | NO |
+
+**关键事实**：Chain A 的 base `856a638` 状态**已经包含 `evm_u256_add/sub` opcodes**（由更早的 dangling commit `5550c9a` 引入）。`git show 856a638:src/compiler/mir/opcodes.def | grep evm_u256` 确认 `evm_u256_add/add_result/sub/sub_result` 在 base 已存在。
+
+而当前 `origin/main` 只有 `evm_u256_mul/mul_result`。**这就是结构性 blocker**。
+
+### §3. files touched (union of 3 chains)
+
+- **Chain A (10 文件)**: `src/compiler/cgir/lowering.h`、`evm_frontend/evm_mir_compiler.{cpp,h}`、`mir/instruction.h`、`mir/instructions.{cpp,h}`、`mir/opcodes.def`、`mir/pass/visitor.h`、`target/x86/x86lowering.{cpp,h}`
+- **Chain B (10 文件，与 A 几乎完全重叠)**
+- **Chain C (22 文件)**: `docs/changes/2026-04-18-...`、`src/compiler/CMakeLists.txt`、`mir/dmir_rewrite_rules.json + v2 (新建)`、`pass/dmir_rewrite.h`、`target/x86/x86_cg_peephole.{cpp,h}`、`tests/CMakeLists.txt`、`dmir_validation_tests.cpp`、`evm_state_tests.cpp`、`utils/evm.cpp`、加 11 个 `tools/*.py`
+
+### §4. 冲突 surface vs 已合 PR
+
+| PR | Squash SHA | 改 `evm_mir_compiler.cpp` 行数 |
+|----|------------|-------------------------------|
+| #458 (u256 batch1+2) | `fca0b1a` | +419 / -31 |
+| #487/#494 (zero const fix) | `4bc30f5` | +12 / -7 |
+| #493 (EVMRangeAnalyzer) | `af60336` | 多次 |
+
+Chain A 改 `evm_mir_compiler.cpp` `+52 / -326`（净负，replace inline expansion with new opcode）。
+**`evm_mir_compiler.{cpp,h}` 同时被 3 个 PR 和 Chain A+B 改动 → 700+ 行同表面 textual overlap**。
+
+### §5. cherry-pick dry-run
+
+```bash
+git checkout -b cherry-pick-test-N7 origin/main
+git cherry-pick --no-commit a34d460  # commit #1 alone
+```
+
+立刻在 **5 个文件** 产生 hard semantic conflict：
+
+```
+src/compiler/mir/instruction.h         (1 hunk)  — EVM_U256_ADD/SUB/BITWISE enum
+src/compiler/mir/instructions.cpp      (2 hunks) — dump switch cases
+src/compiler/mir/instructions.h        (1 hunk)  — Evm_U256_Add/Sub/Bitwise classes
+src/compiler/mir/opcodes.def           (1 hunk)  — OPCODE(evm_u256_add/sub/bitwise) lines
+src/compiler/mir/pass/visitor.h        (2 hunks) — visit dispatch + virtual methods
+```
+
+incoming side 携带 **6 opcodes** (`evm_u256_add/add_result/sub/sub_result/bitwise/bitwise_result`)，**不只是** `a34d460` commit message 说的 2 个。原因：commit `a34d460` 的 base `856a638` 已含 `evm_u256_add/sub`；cherry-pick 把 "delta from main-base" 的 4 个未定义 opcodes 也拉进来。
+
+abort 干净（`git cherry-pick --abort; git branch -D cherry-pick-test-N7`），工作树验证回到 `ci/cache-evmone-bench-fork`。
+
+### §6. Verdict: **MAJOR**
+
+不是 cherry-pick 是 re-implementation：
+
+1. Chain A presupposes `evm_u256_add/sub` opcodes that come from a dangling precursor (`5550c9a`-equivalent) **not in the 13 listed commits**。
+2. `evm_mir_compiler.{cpp,h}` was rewritten by PR #458 / #487 / #493 in the same lines Chain A rewrites by net `-274` — collision is hand-to-hand。
+3. Chain C 依赖 Chain A 尾 `91174d4`，所以无法独立 cherry-pick。
+
+### §7. build sanity: SKIPPED
+
+per audit 协议，仅 CLEAN verdict 才跑 build。本审计 verdict 为 MAJOR → skipping。
+
+## Path Forward (建议，本审计不实施)
+
+若仍想保留 Track B perf 杠杆，需要一个独立 spec：
+
+1. **Re-implement scaffolding** in current main：先在 `mir/opcodes.def`/`instructions.{h,cpp}`/`pass/visitor.h` 增加 `evm_u256_add/sub/bitwise` opcodes scaffolding。
+2. **Re-implement bitwise lowering**：参考 `3319fdf` 的 `target/x86/x86lowering.cpp` 改动思路，但在 #458/#493 之后的 lower 链上重写。
+3. **Re-implement shift lowering**：参考 `ee0c487`/`54d0aae` 的 SHLD/SHRD pattern。
+4. **Re-implement MultiWordAdd/Sub atomic**：参考 `5738f6f`。
+5. **Re-evaluate xor-self synthesized rule**：参考 `250cb7f`/`abfa2a2`/`34656d5`。
+6. **Bench-compare**：post-#458/#493 baseline 实测 Phase 1+2 delta 是否仍然 +4-5% — likely 显著小于 evidence-branch 的数字，因为同表面 surface 已经被 #458 优化吃掉一部分 surplus。
+
+总工作量预估：**multipass×0.5-1 person-week per chain × 3 chains，加上每个 chain 后的 ping-pong bench-compare**。这远超 §2 N7 原始预设的"audit + cherry-pick"。
+
+## Impact
+
+- **方向决策**：next-steps doc §2 N7 应从 "Tier 1 conditional" demote 到 **Tier 3 研究/重写类**，或 **Tier 4 DO NOT START as cherry-pick**。
+- **收尾路径**：§5 收尾标准 中"如果 N7 cherry-pick 落地"分支应删除；当前剩余的 conditional 路径只有"N1 / C-ISZERO / N5 / N6 任一在 27-bench 上 ≥1% per-bench"。
+- **kill condition #2** 风险随之上升：剩余候选若全部 sub-1% per-bench → 6-8 周后 kill direction 几率显著增加。
+
+## Compatibility Notes
+
+无代码改动，无 ABI 影响。
+
+## Risks
+
+- **Risk**：reader 读到本 audit 后可能仍想"试试 cherry-pick" — 文档已明确给出 5 文件冲突清单，应充分。
+- **Mitigation**：在 next-steps doc §2 N7 显式 link 本 audit 文件。
+
+## Checklist
+
+- [x] Audit completed: 3 chains / 13 commits 全部覆盖
+- [x] Dry-run cherry-pick 已 abort 且无残留
+- [x] Conflict 文件清单已 cite
+- [x] Verdict (MAJOR) + 一行总结已给
+- [x] Path forward 已给（不实施）
+
+## References
+
+- Source audit: `~/changes/2026-05-16-u256-direction-scan/` 内 Stage 1 reviewer 报告（task `a0fb216c80185901b`）
+- Parent direction: `docs/research/directions/u256-strength-reduction/`
+- Next-steps scan: `docs/research/directions/u256-strength-reduction/analysis/2026-05-16-next-steps-direction-scan.md` §2 N7
+- verified-opps baseline: `docs/research/directions/u256-strength-reduction/analysis/2026-05-12-verified-opportunities.md` §1.C

--- a/docs/changes/2026-05-16-u256-track-b-audit/README.md
+++ b/docs/changes/2026-05-16-u256-track-b-audit/README.md
@@ -1,22 +1,25 @@
 # Track B Cherry-Pick Feasibility Audit (read-only)
 
-**Status**: Implemented (audit-only, no code change)
+**Status**: Implemented (audit r1, after Phase 4 review)
 **Tier**: Light (doc-only)
 **Created**: 2026-05-16
 **Branch**: docs/u256-track-b-cherry-pick-audit
 
 ## Overview
 
-13 个 dangling commits 在 reflog 中保存了 2026-04 的 "Track B" 评估工作 (`evm_u256_bitwise` AND/OR/XOR 并行 lowering、`evm_u256_shl/shr/sar` SHLD/SHRD lowering、`MultiWordAdd/Sub` atomic、`u256-xor-self` synthesized rule)。`docs/research/directions/u256-strength-reduction/analysis/2026-05-16-next-steps-direction-scan.md` §2 N7 把这条路径标为 Tier 1 conditional — audit 是 Tier 1，cherry-pick 后是否升 Tier 取决于实测 delta。
+13 个 evidence-branch commits 保存了 2026-04 的 "Track B" 评估工作 (`evm_u256_bitwise` AND/OR/XOR 并行 lowering、`evm_u256_shl/shr/sar` SHLD/SHRD lowering、`MultiWordAdd/Sub` atomic、`u256-xor-self` synthesized rule)。这些 commits **不在 `origin/main` 上**，但仍在两个 evidence branch 中存活：
 
-本审计**只读**地评估"cherry-pick 到当前 main 的可行性"。**Verdict: MAJOR — 不是 cherry-pick，是 re-implementation 任务**。
+- `origin/perf/peephole-rule-expansion` — 含 Chain A 全部 9 commits + Chain C 全部 6 commits
+- `origin/feat/cgir-peephole-pr` (PR #439 draft) — 含 Chain B 的 `5738f6f`
+
+本审计**只读**地评估"cherry-pick 到当前 `origin/main` 的可行性"。**Verdict: MAJOR — 不是 cherry-pick，是 re-implementation 任务**。
 
 ## Motivation
 
-verified-opps §1.C 报告 Phase 1 (bitwise) +3.421% geomean、Phase 2 (shifts) +1.538% additional、blake2b_huff +13%、sha1_shifts +8.5%（2026-04 baseline window 实测）。这是当前 U256 强度削减方向**最大杠杆点**：
+`docs/research/directions/u256-strength-reduction/analysis/2026-05-12-verified-opportunities.md` §1.C 报告 Phase 1 (bitwise) +3.421% geomean、Phase 2 (shifts) +1.538% additional、blake2b_huff +13%、sha1_shifts +8.5%（2026-04 baseline window 实测）。这是当前 U256 强度削减方向**最大杠杆点**：
 
 - 若 cherry-pick 可行 → 实测 ≥3% geomean → 方向自然收尾，转 next direction
-- 若 不可行 → 沿 N1/N2/C-ISZERO/N5/N6 走完，6-8 周内拿到 ≥1 个 ≥1% per-bench 信号否则 kill direction (per §5 收尾标准)
+- 若 不可行 → 沿 N1 / C-ISZERO / N5 / N6 走完，6-8 周内拿到 ≥1 个 ≥1% per-bench 信号否则 kill direction (per `2026-05-16-next-steps-direction-scan.md` §5 收尾标准)
 
 因此 audit 结论直接 gate 下一阶段决策。
 
@@ -24,7 +27,7 @@ verified-opps §1.C 报告 Phase 1 (bitwise) +3.421% geomean、Phase 2 (shifts) 
 
 ### §1. 13 commits 拓扑
 
-**不是单一线性 chain，是 3 条独立 chain**：
+**不是单一线性 chain，是 3 条独立 chain**（用 `git log --pretty=format:'%h %p' -1 <sha>` 抽样验证 parent SHA 全部确认）：
 
 ```
 Chain A (9 commits, base 856a638):
@@ -34,12 +37,12 @@ Chain A (9 commits, base 856a638):
 Chain B (1 commit, base 998d9c6, completely independent of A/C):
   998d9c6 → 5738f6f
 
-Chain C (3 commits, base 9e7b2b6, independent of A/B):
+Chain C (3+ commits, two-rooted; 9e7b2b6 fork + 91174d4-derived fork):
   9e7b2b6 → abfa2a2 → 34656d5
-  (加 250cb7f 经由 883a6ac → 60cdf0f → 49f2ba8 → 91174d4 接到 Chain A 尾)
+  91174d4 → 49f2ba8 → 60cdf0f → 883a6ac → 250cb7f
 ```
 
-原 `2026-05-16-next-steps-direction-scan.md` §2 N7 列表中 `8dbe3f3 / 91174d4 / 69628db` 三 commit 顺序错乱 — 真实 chain 序为 `54d0aae→8dbe3f3→19daebe→69628db→91174d4`。
+Chain C 实际有 **两个 base** (`9e7b2b6` 与 `91174d4`)。原 `2026-05-16-next-steps-direction-scan.md` §2 N7 source 列表中 **≥4 个 SHA 顺序错乱**: `54d0aae`、`8dbe3f3`、`91174d4`、`69628db`，真实 chain 序为 `…/ee0c487/54d0aae/8dbe3f3/19daebe/69628db/91174d4`。
 
 ### §2. base commit 与 origin/main 距离
 
@@ -47,57 +50,82 @@ Chain C (3 commits, base 9e7b2b6, independent of A/B):
 |-------|------|--------------------------------------|--------------------------|
 | A | `856a638` | 35 | NO |
 | B | `998d9c6` | 24 | NO |
-| C | `883a6ac` / `9e7b2b6` | n/a | NO |
+| C | `9e7b2b6` / `91174d4` | n/a | NO |
 
-**关键事实**：Chain A 的 base `856a638` 状态**已经包含 `evm_u256_add/sub` opcodes**（由更早的 dangling commit `5550c9a` 引入）。`git show 856a638:src/compiler/mir/opcodes.def | grep evm_u256` 确认 `evm_u256_add/add_result/sub/sub_result` 在 base 已存在。
+**关键事实（load-bearing）**：Chain A 的 base `856a638` 状态**已经包含 `evm_u256_add/sub` opcodes**（由更早的 commit `5550c9a` 引入；`5550c9a` 是 PR #439 draft 链上的，**不在本 audit 的 13 个 commits 列表内**）。
 
-而当前 `origin/main` 只有 `evm_u256_mul/mul_result`。**这就是结构性 blocker**。
+```bash
+$ git show 856a638:src/compiler/mir/opcodes.def | grep evm_u256
+# 返回 mul/mul_result + add/add_result + sub/sub_result
+
+$ git show origin/main:src/compiler/mir/opcodes.def | grep evm_u256
+# 只返回 mul/mul_result
+```
+
+**这就是结构性 blocker**。
 
 ### §3. files touched (union of 3 chains)
 
-- **Chain A (10 文件)**: `src/compiler/cgir/lowering.h`、`evm_frontend/evm_mir_compiler.{cpp,h}`、`mir/instruction.h`、`mir/instructions.{cpp,h}`、`mir/opcodes.def`、`mir/pass/visitor.h`、`target/x86/x86lowering.{cpp,h}`
-- **Chain B (10 文件，与 A 几乎完全重叠)**
-- **Chain C (22 文件)**: `docs/changes/2026-04-18-...`、`src/compiler/CMakeLists.txt`、`mir/dmir_rewrite_rules.json + v2 (新建)`、`pass/dmir_rewrite.h`、`target/x86/x86_cg_peephole.{cpp,h}`、`tests/CMakeLists.txt`、`dmir_validation_tests.cpp`、`evm_state_tests.cpp`、`utils/evm.cpp`、加 11 个 `tools/*.py`
+数据来源：`git show --name-only <sha> | sort -u` for 每个 chain 的全部 commits union。
+
+- **Chain A (10 文件)**: `src/compiler/cgir/lowering.h`、`src/compiler/evm_frontend/evm_mir_compiler.{cpp,h}`、`src/compiler/mir/instruction.h`、`src/compiler/mir/instructions.{cpp,h}`、`src/compiler/mir/opcodes.def`、`src/compiler/mir/pass/visitor.h`、`src/compiler/target/x86/x86lowering.{cpp,h}`
+- **Chain B (10 文件，与 Chain A fully overlapping — same 10 paths)**
+- **Chain C (9 unique 文件)**:
+  - `src/compiler/mir/dmir_rewrite_rules.json`
+  - `src/compiler/mir/pass/dmir_rewrite.h`
+  - `src/tests/CMakeLists.txt`
+  - `src/tests/dmir_validation_tests.cpp`
+  - `tools/check_dmir_rewrite_rules.py`
+  - `tools/mine_dmir_seed_rules.py`
+  - `tools/synthesize_dmir_rules.py`
+  - `tools/test_verify_dmir_u256_soundness.py`
+  - `tools/verify_dmir_u256_soundness.py`
+
+Chain C 不与 Chain A/B 共享任何 `src/compiler/{mir,evm_frontend,target,cgir}` 表面（其重点在 dmir rewrite 规则与 synthesis 工具）。
 
 ### §4. 冲突 surface vs 已合 PR
 
-| PR | Squash SHA | 改 `evm_mir_compiler.cpp` 行数 |
-|----|------------|-------------------------------|
-| #458 (u256 batch1+2) | `fca0b1a` | +419 / -31 |
-| #487/#494 (zero const fix) | `4bc30f5` | +12 / -7 |
-| #493 (EVMRangeAnalyzer) | `af60336` | 多次 |
+| PR | Squash SHA | 改 `evm_mir_compiler.cpp` 行数 | 改 cpp+h 行数 | 说明 |
+|----|------------|-------------------------------|---------------|------|
+| #458 (u256 batch1+2) | `fca0b1a` | `+388 / -31` | `+479 / -34` | 主表面 |
+| #487/#494 (zero const fix) | `4bc30f5` | `+12 / -7` | — | 小补丁 |
+| #493 (EVMRangeAnalyzer) | `af60336` | `+5 / -2` | — | bulk 在 `evm_analyzer.h` (+546) 与新文件，**不在 evm_mir_compiler.cpp** |
 
 Chain A 改 `evm_mir_compiler.cpp` `+52 / -326`（净负，replace inline expansion with new opcode）。
-**`evm_mir_compiler.{cpp,h}` 同时被 3 个 PR 和 Chain A+B 改动 → 700+ 行同表面 textual overlap**。
+
+**评估冲突面**：`evm_mir_compiler.cpp` 同时被 #458 (`+388/-31`) 和 Chain A (`+52/-326`) 改 — sum ≈ 783 lines 在同一文件改动。`evm_analyzer.h` 是 #493 主表面但 Chain A 不动；Chain A 的 `.h` 影响主要在 `evm_mir_compiler.h`。
 
 ### §5. cherry-pick dry-run
+
+独立在 `/tmp/dtvm-cherry-test` 与 worktree 双方分别 reproduce：
 
 ```bash
 git checkout -b cherry-pick-test-N7 origin/main
 git cherry-pick --no-commit a34d460  # commit #1 alone
 ```
 
-立刻在 **5 个文件** 产生 hard semantic conflict：
+立刻在 **5 个文件** 产生 hard semantic conflict（`grep -c '^<<<<<<< ' <file>` 数 hunk）：
 
-```
-src/compiler/mir/instruction.h         (1 hunk)  — EVM_U256_ADD/SUB/BITWISE enum
-src/compiler/mir/instructions.cpp      (2 hunks) — dump switch cases
-src/compiler/mir/instructions.h        (1 hunk)  — Evm_U256_Add/Sub/Bitwise classes
-src/compiler/mir/opcodes.def           (1 hunk)  — OPCODE(evm_u256_add/sub/bitwise) lines
-src/compiler/mir/pass/visitor.h        (2 hunks) — visit dispatch + virtual methods
-```
+| 文件 | hunk 数 | conflict 内容 |
+|------|--------|--------------|
+| `src/compiler/mir/instruction.h` | 1 | `EVM_U256_ADD/SUB/BITWISE` enum |
+| `src/compiler/mir/instructions.cpp` | 2 | dump switch cases |
+| `src/compiler/mir/instructions.h` | 1 | `Evm_U256_Add/Sub/Bitwise` classes |
+| `src/compiler/mir/opcodes.def` | 1 | `OPCODE(evm_u256_add/sub/bitwise)` lines |
+| `src/compiler/mir/pass/visitor.h` | 2 | visit dispatch + virtual methods |
 
-incoming side 携带 **6 opcodes** (`evm_u256_add/add_result/sub/sub_result/bitwise/bitwise_result`)，**不只是** `a34d460` commit message 说的 2 个。原因：commit `a34d460` 的 base `856a638` 已含 `evm_u256_add/sub`；cherry-pick 把 "delta from main-base" 的 4 个未定义 opcodes 也拉进来。
+incoming side 携带 **6 opcodes** (`evm_u256_add/add_result/sub/sub_result/bitwise/bitwise_result`)，**不只是** `a34d460` commit message 说的 2 个（bitwise/bitwise_result）。原因：commit `a34d460` 的 base `856a638` 已含 `evm_u256_add/sub`；cherry-pick 把 "delta from main-base" 的 4 个未定义 opcodes 也拉进来。这是 §6 verdict 的 single most decision-relevant insight。
 
-abort 干净（`git cherry-pick --abort; git branch -D cherry-pick-test-N7`），工作树验证回到 `ci/cache-evmone-bench-fork`。
+dry-run 后 abort 干净（`git cherry-pick --abort; git branch -D cherry-pick-test-N7`），工作树验证回到 `ci/cache-evmone-bench-fork`。
 
 ### §6. Verdict: **MAJOR**
 
 不是 cherry-pick 是 re-implementation：
 
-1. Chain A presupposes `evm_u256_add/sub` opcodes that come from a dangling precursor (`5550c9a`-equivalent) **not in the 13 listed commits**。
-2. `evm_mir_compiler.{cpp,h}` was rewritten by PR #458 / #487 / #493 in the same lines Chain A rewrites by net `-274` — collision is hand-to-hand。
-3. Chain C 依赖 Chain A 尾 `91174d4`，所以无法独立 cherry-pick。
+1. Chain A presupposes `evm_u256_add/sub` opcodes that come from precursor `5550c9a` (PR #439 draft 链)，**not in the 13 listed commits**.
+2. `evm_mir_compiler.cpp` 被 #458 (`+388/-31`) 和 Chain A (`+52/-326`) 改动同表面 ≈ 783 lines collision 不是 textual whitespace level。
+3. Chain C 的 5 commit 子链 (`91174d4 → 49f2ba8 → 60cdf0f → 883a6ac → 250cb7f`) 依赖 Chain A 尾 `91174d4`，无法独立 cherry-pick。
+4. Chain B 与 Chain A files fully overlapping，独立 cherry-pick 也会撞 #458。
 
 ### §7. build sanity: SKIPPED
 
@@ -107,19 +135,19 @@ per audit 协议，仅 CLEAN verdict 才跑 build。本审计 verdict 为 MAJOR 
 
 若仍想保留 Track B perf 杠杆，需要一个独立 spec：
 
-1. **Re-implement scaffolding** in current main：先在 `mir/opcodes.def`/`instructions.{h,cpp}`/`pass/visitor.h` 增加 `evm_u256_add/sub/bitwise` opcodes scaffolding。
-2. **Re-implement bitwise lowering**：参考 `3319fdf` 的 `target/x86/x86lowering.cpp` 改动思路，但在 #458/#493 之后的 lower 链上重写。
+1. **Decide whether `evm_u256_add/sub` pseudo-ops are still needed post-#458**: PR #458 的 batch1+2 已经 inline ADD/SUB barrier 消除策略到 `evm_mir_compiler.cpp` 现有路径上。Chain A 的 add/sub scaffolding 是为了把 ADD/SUB U256 lowered 成专用 opcode；但 #458 实现路径是不引入新 opcode 的。**需要先判定**：保留 #458 路径继续在其上加 bitwise/shift？还是回滚 #458 改用 atomic-opcode 路径？这影响 step 2-5 是否仍然适用。
+2. **Re-implement bitwise lowering** (取决于 step 1 决策)：参考 `3319fdf` 的 `target/x86/x86lowering.cpp` 改动思路，但在 #458/#493 之后的 lower 链上重写。
 3. **Re-implement shift lowering**：参考 `ee0c487`/`54d0aae` 的 SHLD/SHRD pattern。
-4. **Re-implement MultiWordAdd/Sub atomic**：参考 `5738f6f`。
-5. **Re-evaluate xor-self synthesized rule**：参考 `250cb7f`/`abfa2a2`/`34656d5`。
-6. **Bench-compare**：post-#458/#493 baseline 实测 Phase 1+2 delta 是否仍然 +4-5% — likely 显著小于 evidence-branch 的数字，因为同表面 surface 已经被 #458 优化吃掉一部分 surplus。
+4. **Re-implement MultiWordAdd/Sub atomic** (取决于 step 1 决策)：参考 `5738f6f`，或决定保留 #458 路径。
+5. **Re-evaluate xor-self synthesized rule** in Chain C：参考 `250cb7f`/`abfa2a2`/`34656d5`，看 #493 EVMRangeAnalyzer 是否已经能 derive 同样优化。
+6. **Bench-compare**：post-#458/#493 baseline 实测 Phase 1+2 delta 是否仍然 +4-5%。**显著小于 evidence-branch 数字的概率高**，因为 #458 已经吃掉部分 surplus；具体 fraction 需要实测，audit 不预测。
 
-总工作量预估：**multipass×0.5-1 person-week per chain × 3 chains，加上每个 chain 后的 ping-pong bench-compare**。这远超 §2 N7 原始预设的"audit + cherry-pick"。
+工作量是 multi-chain re-implementation，远超 §2 N7 原始预设的"audit + cherry-pick"。
 
 ## Impact
 
-- **方向决策**：next-steps doc §2 N7 应从 "Tier 1 conditional" demote 到 **Tier 3 研究/重写类**，或 **Tier 4 DO NOT START as cherry-pick**。
-- **收尾路径**：§5 收尾标准 中"如果 N7 cherry-pick 落地"分支应删除；当前剩余的 conditional 路径只有"N1 / C-ISZERO / N5 / N6 任一在 27-bench 上 ≥1% per-bench"。
+- **方向决策**：`2026-05-16-next-steps-direction-scan.md` §2 N7 应从 "Tier 1 conditional" demote 到 **Tier 3 研究/重写类**。
+- **收尾路径**：next-steps doc §5 收尾标准 中"如果 N7 cherry-pick 落地"分支应删除；当前剩余的 conditional 路径只有"N1 / C-ISZERO / N5 / N6 任一在 27-bench 上 ≥1% per-bench"。
 - **kill condition #2** 风险随之上升：剩余候选若全部 sub-1% per-bench → 6-8 周后 kill direction 几率显著增加。
 
 ## Compatibility Notes
@@ -128,20 +156,35 @@ per audit 协议，仅 CLEAN verdict 才跑 build。本审计 verdict 为 MAJOR 
 
 ## Risks
 
-- **Risk**：reader 读到本 audit 后可能仍想"试试 cherry-pick" — 文档已明确给出 5 文件冲突清单，应充分。
+- **Risk**：reader 读到本 audit 后可能仍想"试试 cherry-pick" — 文档已明确给出 5 文件冲突清单与 6-opcode leakage 解释，应充分。
 - **Mitigation**：在 next-steps doc §2 N7 显式 link 本 audit 文件。
 
 ## Checklist
 
 - [x] Audit completed: 3 chains / 13 commits 全部覆盖
 - [x] Dry-run cherry-pick 已 abort 且无残留
-- [x] Conflict 文件清单已 cite
+- [x] Conflict 文件清单已 cite (5 files, hunk counts 1/2/1/1/2)
 - [x] Verdict (MAJOR) + 一行总结已给
 - [x] Path forward 已给（不实施）
+- [x] Phase 4 reviewer (Opus + Codex) 已 round 1，all factual edits applied in r1
 
 ## References
 
-- Source audit: `~/changes/2026-05-16-u256-direction-scan/` 内 Stage 1 reviewer 报告（task `a0fb216c80185901b`）
-- Parent direction: `docs/research/directions/u256-strength-reduction/`
-- Next-steps scan: `docs/research/directions/u256-strength-reduction/analysis/2026-05-16-next-steps-direction-scan.md` §2 N7
-- verified-opps baseline: `docs/research/directions/u256-strength-reduction/analysis/2026-05-12-verified-opportunities.md` §1.C
+本 audit 的所有 git command 与 dry-run 都可独立在 `origin/main` 上 reproduce — 不依赖 gitignored 私有路径。验证用关键命令：
+
+```bash
+git show 856a638:src/compiler/mir/opcodes.def | grep evm_u256
+git show origin/main:src/compiler/mir/opcodes.def | grep evm_u256
+git rev-list --count 856a638..origin/main
+git rev-list --count 998d9c6..origin/main
+git show --name-only <sha> | sort -u   # per Chain C commits
+git show --numstat fca0b1a -- src/compiler/evm_frontend/evm_mir_compiler.cpp
+git show --numstat af60336 -- src/compiler/evm_frontend/evm_mir_compiler.cpp
+git checkout -b temp-verify origin/main && git cherry-pick --no-commit a34d460
+# 5 conflicts; then: git cherry-pick --abort; git checkout -; git branch -D temp-verify
+```
+
+相关研究方向（在 `docs/research/` nested clone，本 PR 不包含）：
+- `docs/research/directions/u256-strength-reduction/` — 方向 SSOT
+- `docs/research/directions/u256-strength-reduction/analysis/2026-05-12-verified-opportunities.md` §1.C — Track B Phase 1+2 实测基线
+- `docs/research/directions/u256-strength-reduction/analysis/2026-05-16-next-steps-direction-scan.md` §2 N7 — 当前 demote 目标


### PR DESCRIPTION
## Summary

Read-only feasibility audit covering a set of evidence-branch commits
(on `origin/perf/peephole-rule-expansion` and `origin/feat/cgir-
peephole-pr`) that introduced `evm_u256_bitwise` parallel lowering,
`evm_u256_shl/shr/sar` SHLD/SHRD lowering, and `MultiWordAdd/Sub`
atomic instructions before mainline absorbed PR #458 (u256 batch1+2)
and PR #493 (EVMRangeAnalyzer).

**Conclusion**: cherry-picking those commits onto current
`origin/main` is structurally impossible — the first commit alone
produces a 5-file semantic conflict (`opcodes.def`,
`instructions.{h,cpp}`, `pass/visitor.h`, `instruction.h`) because its
implicit base already contains `evm_u256_add/sub` opcodes from a
precursor commit not in the cherry-pick set, while mainline only has
`evm_u256_mul/mul_result`. Reintroducing the work requires a
re-implementation pass that first decides whether `evm_u256_add/sub`
pseudo-ops are still needed after PR #458 already inlined the
ADD/SUB barrier-elimination path without new opcodes.

## What this PR is

A single `docs/changes/2026-05-16-u256-track-b-audit/README.md` file
documenting:
- the 3-chain topology of the evidence commits and their bases
- the file overlap with merged PRs
- the conflict files + hunk counts (reproducible from `origin/main`)
- the structural blocker (precursor opcode dependency)
- a `Path Forward` outlining a 6-step re-implementation sequence

All git commands and the cherry-pick dry-run are reproducible from
`origin/main`; the body of the audit does not depend on any private
or gitignored paths.

## Test plan

- No code change; only `docs/changes/` add
- `tools/format.sh check` — pass

## DRAFT — personal fork integration test

Drafting on `abmcar/DTVM` (personal fork). Not yet for upstream.