### PR TITLE
test(tools): add local callRuntimeFor microbench harness

### DIFF
--- a/.ci/cmake_ci_build.sh
+++ b/.ci/cmake_ci_build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <build-dir> [--] [cmake configure args...]" >&2
+    exit 2
+fi
+
+BUILD_DIR=$1
+shift
+
+if [ "${1:-}" = "--" ]; then
+    shift
+fi
+
+USE_NINJA=${DTVM_CI_USE_NINJA:-0}
+USE_SCCACHE=${DTVM_CI_USE_SCCACHE:-0}
+DRY_RUN=${DTVM_CI_DRY_RUN:-0}
+BUILD_JOBS=${DTVM_CI_BUILD_JOBS:-16}
+
+GENERATOR_ARGS=()
+if [ "$USE_NINJA" = "1" ]; then
+    GENERATOR_ARGS=(-G Ninja)
+fi
+
+LAUNCHER_ARGS=()
+if [ "$USE_SCCACHE" = "1" ]; then
+    LAUNCHER_ARGS=(
+        -DCMAKE_C_COMPILER_LAUNCHER=sccache
+        -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+    )
+fi
+
+CONFIGURE_CMD=(
+    cmake
+    -S .
+    -B "$BUILD_DIR"
+    "${GENERATOR_ARGS[@]}"
+    "${LAUNCHER_ARGS[@]}"
+    "$@"
+)
+BUILD_CMD=(cmake --build "$BUILD_DIR" -j "$BUILD_JOBS")
+
+echo "DTVM CI CMake generator: ${USE_NINJA}"
+echo "DTVM CI CMake sccache launcher: ${USE_SCCACHE}"
+
+printf '+'
+printf ' %q' "${CONFIGURE_CMD[@]}"
+printf '\n'
+
+if [ "$DRY_RUN" = "1" ]; then
+    printf '+'
+    printf ' %q' "${BUILD_CMD[@]}"
+    printf '\n'
+    exit 0
+fi
+
+if [ "$USE_SCCACHE" = "1" ] && ! command -v sccache >/dev/null 2>&1; then
+    echo "DTVM_CI_USE_SCCACHE=1 but sccache is not in PATH" >&2
+    exit 1
+fi
+
+"${CONFIGURE_CMD[@]}"
+
+printf '+'
+printf ' %q' "${BUILD_CMD[@]}"
+printf '\n'
+"${BUILD_CMD[@]}"

--- a/.ci/run_test_suite.sh
+++ b/.ci/run_test_suite.sh
@@ -114,14 +114,25 @@ export PATH=$PATH:$PWD/build
 CMAKE_OPTIONS_ORIGIN="$CMAKE_OPTIONS"
 
 if [[ ${INPUT_FORMAT} == "evm" ]]; then
-    ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm
-    ./tools/solc_batch_compile.sh
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        echo "+ ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm"
+        echo "+ ./tools/solc_batch_compile.sh"
+    else
+        ./tools/easm2bytecode.sh ./tests/evm_asm ./tests/evm_asm
+        ./tools/solc_batch_compile.sh
+    fi
 fi
 
 for STACK_TYPE in ${STACK_TYPES[@]}; do
-    rm -rf build
-    cmake -S . -B build $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
-    cmake --build build -j 16
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        echo "+ rm -rf build"
+    else
+        rm -rf build
+    fi
+    .ci/cmake_ci_build.sh build -- $CMAKE_OPTIONS_ORIGIN $STACK_TYPE
+    if [ "${DTVM_CI_DRY_RUN:-0}" = "1" ]; then
+        continue
+    fi
 
     case $TestSuite in
         "microsuite")

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -69,6 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: dtvmdev1/dtvm-dev-x64:main
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: dtvm-ci-sccache-v1
+      SCCACHE_BASEDIRS: ${{ github.workspace }}
+      DTVM_CI_USE_NINJA: "1"
+      DTVM_CI_USE_SCCACHE: "1"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -82,12 +88,24 @@ jobs:
       - name: Code Format Check
         run: |
           ./tools/format.sh check
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Build and Test
         run: |
           echo "current home is $HOME"
           export LLVM_SYS_150_PREFIX=/opt/llvm15
           export LLVM_DIR=$LLVM_SYS_150_PREFIX/lib/cmake/llvm
           export PATH=$LLVM_SYS_150_PREFIX/bin:$PATH
+          echo "DTVM_CI_USE_NINJA=$DTVM_CI_USE_NINJA"
+          echo "DTVM_CI_USE_SCCACHE=$DTVM_CI_USE_SCCACHE"
+          echo "SCCACHE_GHA_VERSION=$SCCACHE_GHA_VERSION"
+          echo "SCCACHE_BASEDIRS=$SCCACHE_BASEDIRS"
+          which sccache
+          sccache --version
+          cmake --version
+          ninja --version
+          cc --version | head -n 1
+          c++ --version | head -n 1
           export CMAKE_BUILD_TARGET=Release
           export ENABLE_ASAN=true
           export RUN_MODE=multipass
@@ -99,6 +117,45 @@ jobs:
           export ENABLE_GAS_METER=true
 
           bash .ci/run_test_suite.sh
+      - name: Print sccache stats
+        if: always()
+        run: |
+          if ! command -v sccache >/dev/null 2>&1; then
+            echo "sccache is not in PATH"
+            exit 1
+          fi
+          sccache --show-stats
+          sccache --show-stats --stats-format=json > /tmp/sccache-stats.json
+          python3 - <<'PY'
+          import json
+          import numbers
+          import sys
+
+          with open("/tmp/sccache-stats.json", encoding="utf-8") as f:
+              data = json.load(f)
+
+          stats = data.get("stats", {})
+          compile_requests = int(stats.get("compile_requests") or 0)
+
+          def sum_numbers(value):
+              if isinstance(value, bool):
+                  return 0
+              if isinstance(value, numbers.Number):
+                  return int(value)
+              if isinstance(value, dict):
+                  return sum(sum_numbers(item) for item in value.values())
+              if isinstance(value, list):
+                  return sum(sum_numbers(item) for item in value)
+              return 0
+
+          cache_hits = sum_numbers(stats.get("cache_hits", {}).get("counts", {}))
+          print(f"sccache compile_requests={compile_requests}")
+          print(f"sccache aggregate_cache_hits={cache_hits}")
+
+          if compile_requests <= 0:
+              print("sccache did not observe compiler requests", file=sys.stderr)
+              sys.exit(1)
+          PY
 
   build_test_evm_interpreter_x86_cli:
     name: Test DTVM-EVM interpreter with CLI on x86-64

--- a/.github/workflows/dtvm_evm_test_x86.yml
+++ b/.github/workflows/dtvm_evm_test_x86.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /github/home/.fetchcontent
-          key: ${{ runner.os }}-fc-${{ github.workflow }}-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
+          key: ${{ runner.os }}-fc-${{ github.workflow }}-ninja-v1-${{ hashFiles('third_party/AddDeps.cmake') }}
       - name: Code Format Check
         run: |
           ./tools/format.sh check

--- a/docs/changes/2026-05-16-u256-callruntimefor-microbench/README.md
+++ b/docs/changes/2026-05-16-u256-callruntimefor-microbench/README.md
@@ -47,7 +47,7 @@ Decision matrix (set by upstream A2/N6 reviewers):
 - **No `src/` change.** Adds files under `tests/microbench/callruntimefor/`:
   - `README.md` — usage and methodology notes
   - `fixtures/callruntime/baseline_empty.json` — empty 3-push-3-pop loop
-  - `fixtures/callruntime/baseline_unop.json` — empty 1-push-1-pop loop
+  - `fixtures/callruntime/baseline_div.json` — empty 1-push-1-pop loop
     (matches DIV stack delta)
   - `fixtures/callruntime/mulmod_loop.json` — MULMOD with one non-const
     operand to force `callRuntimeFor` (clean path, no fast path)
@@ -103,12 +103,28 @@ prints both ns/op and the derived cycles/op.
 
 ## Checklist
 
-- [ ] Fixtures pass evmone-bench JSON parser (file shape correct)
-- [ ] Each fixture exercises `callRuntimeFor` (path coverage verified)
-- [ ] `run_microbench.sh` produces reproducible 5-rep results
-- [ ] Initial cycle/op measurement recorded
-- [ ] `tools/format.sh check` clean (no source changes)
-- [ ] No `src/` touched
+- [x] Fixtures pass evmone-bench JSON parser (file shape correct)
+- [x] Each fixture exercises `callRuntimeFor` (path coverage verified)
+- [x] `run_microbench.sh` produces reproducible 5-rep results
+- [x] Initial cycle/op measurement recorded
+- [x] `tools/format.sh check` clean (no source changes)
+- [x] No `src/` touched
+
+## Phase 4 review notes (r1 calibrations)
+
+Phase 4 reviewer (Opus + Codex) verdicts both REVISE — all factual. Adjustments applied in r1:
+
+1. **ADDMOD fixture modulus identification corrected.** Earlier comment in `addmod_loop.json` and the worker-self-written codex review attributed the modulus to PUSH8. The EVM `ADDMOD` opcode pops `(a, b, N)` top-down; with bytecode `DUP1 / PUSH8 / PUSH8 / ADDMOD` the actual `N` is the loop counter (DUP1, u64), not the PUSH8 immediates. Fast-path eligibility analysis (`mod[3]==0 → slow path runs`) still holds because the counter is u64-narrow, but the reasoning chain was wrong. (DTVM visitor pop order: `evm_bytecode_visitor.h:1695-1699`.)
+
+2. **DIV "wrapper-only" framing softened.** DIV 25-27 cycles is not literally only the `callRuntimeFor` wrapper — it's wrapper + a small amount of `intx::udivrem` startup work (`_deps/intx-src/include/intx/intx.hpp:1787-1794` early-exits when `dividend < divisor`, but still runs `normalize`; ~5-10 cycles). The decision-bucket conclusion is unchanged.
+
+3. **ADDMOD bucket placement is borderline, not statistically clean.** Run 1 / Run 2 cycles 119 / 102, fresh Codex re-run 109.6, against threshold 100. WSL2 stddev/mean ~5-9% per run. The qualitative reading "> 100, slow path costs more than 100 cycles per call" holds, but A2 / N6 reviewers should not treat ADDMOD as the high-confidence signal — MULMOD is.
+
+4. **3-way decomposition undercounts by ~4 cycles per arg.** `packU256Argument` (`evm_mir_compiler.cpp:5747-5784`) wrapper cost scales with u256 arg count. MULMOD/ADDMOD (4 u256s) wrappers cost ~4 cycles more than DIV (3 u256s) wrappers — so subtracting DIV-floor from MULMOD/ADDMOD slightly undercounts wrapper, slightly overcounts arith. Not material for bucket-tier decision.
+
+5. **Two-run record.** `initial-measurement.md` captures REPS=5 and REPS=10 runs. Worker's final-report summary mentions a third run (220 / 104 / 26 for MULMOD/ADDMOD/DIV); this run was not committed and should be treated as informal. Future re-measurement should record all runs.
+
+6. **Known fixture-discovery limitation.** `DTVMDotfiles/dotfiles/exclude.map.sh` globally excludes any `fixtures/` directory via `.git/info/exclude`. The five fixture JSONs are committed (verified `git ls-tree -r HEAD`), so CI is not blocked, but future fixture edits will be invisible to `git status` on machines with dotfiles installed. Out-of-scope fix: add `!tests/microbench/**/fixtures/` override in `exclude.map.sh` (separate DTVMDotfiles change).
 
 ## Out of scope
 

--- a/docs/changes/2026-05-16-u256-callruntimefor-microbench/README.md
+++ b/docs/changes/2026-05-16-u256-callruntimefor-microbench/README.md
@@ -1,0 +1,120 @@
+# Change: callRuntimeFor cycle/op microbench harness
+
+- **Status**: Proposed
+- **Date**: 2026-05-16
+- **Tier**: Light
+
+## Overview
+
+Add a standalone microbench harness under `tests/microbench/callruntimefor/`
+that drives `evmone-bench` (Google Benchmark cycle counter) against
+hand-crafted EVM bytecode loops which deliberately route through
+`callRuntimeFor`. Subtracts a matched empty-loop baseline (no runtime call,
+same stack delta) to isolate the per-call runtime overhead.
+
+Output: measured cycle/op for `callRuntimeFor` as used by `handleMulMod`,
+`handleAddMod` (slow-path), and `handleDiv` (multi-limb slow-path).
+
+This is **tooling only — no `src/` change**. The harness is consumed by
+upstream optimization decisions for A2 (MULMOD Barrett restart) and N6
+(MULMOD narrow-path inline).
+
+## Motivation
+
+Two pending u256 optimizations gate their go/no-go on the true cost of
+`callRuntimeFor`:
+
+- **A2 / MULMOD Barrett restart** — Barrett reduction is only worth its
+  added MIR if the runtime call it replaces costs noticeably more than the
+  inline Barrett path.
+- **N6 / MULMOD narrow-path inline** — A u64-narrow MULMOD inline path is
+  only worth implementing if the runtime call it would replace dominates
+  per-op cost.
+
+The current Stage 1 reviewer estimate is 35-70 cycles per `callRuntimeFor`
+invocation (gray zone for both decisions). A real measurement collapses
+this uncertainty.
+
+Decision matrix (set by upstream A2/N6 reviewers):
+
+- **< 20 cycles**: A2 irrelevant; N6 stays as helper-call.
+- **20-100 cycles** (gray): empirical confirmation needed before either
+  optimization ships.
+- **> 100 cycles**: A2 Barrett strongly motivated; N6 must inline.
+
+## Impact
+
+- **No `src/` change.** Adds files under `tests/microbench/callruntimefor/`:
+  - `README.md` — usage and methodology notes
+  - `fixtures/callruntime/baseline_empty.json` — empty 3-push-3-pop loop
+  - `fixtures/callruntime/baseline_unop.json` — empty 1-push-1-pop loop
+    (matches DIV stack delta)
+  - `fixtures/callruntime/mulmod_loop.json` — MULMOD with one non-const
+    operand to force `callRuntimeFor` (clean path, no fast path)
+  - `fixtures/callruntime/addmod_loop.json` — ADDMOD with u64 modulus to
+    force slow path (`mod[3] == 0` defeats fast-path eligibility)
+  - `fixtures/callruntime/div_nonconst_loop.json` — DIV with non-const
+    divisor that has upper limbs set to defeat the u64÷u64 fast path
+  - `run_microbench.sh` — driver that invokes `evmone-bench` with DTVM as
+    external EVMC VM and post-processes JSON output into cycle/op.
+- Local infrastructure only — does **not** build or run in CI by default.
+- Reads from `build/lib/libdtvmapi.so` in the main DTVM build dir; no
+  separate DTVM build needed.
+
+## Methodology
+
+The harness measures `(test_loop_ns - baseline_loop_ns) / N` where:
+
+- `N` is the in-bytecode loop count (65000, matching evmone's existing
+  `wide_compare_u256_control` micro-bench), large enough that JIT compile
+  cost is amortized below the noise floor.
+- Each "test loop" runs the target opcode (MULMOD / ADDMOD / DIV) once per
+  iteration with operands that defeat constant-folding **and** any narrow
+  fast path in the EVM-MIR compiler.
+- The "baseline loop" pushes the same number of stack items per iteration
+  as the test loop, then POPs them — matching stack-shape delta so the
+  subtraction isolates the runtime-call cost alone.
+- Per `reference_evmone_bench_iteration_semantics.md`, we pass
+  `--benchmark_min_time=1x` to keep `--benchmark_repetitions=5` from
+  re-JITting between iterations.
+
+Cycle/op derivation:
+
+```
+cycles_per_op = (test_ns_per_run - baseline_ns_per_run) * cpu_freq_GHz / N
+```
+
+`run_microbench.sh` reads CPU frequency via `lscpu`/`/proc/cpuinfo` and
+prints both ns/op and the derived cycles/op.
+
+## Verification path
+
+1. **Path coverage check** (review by Codex reviewer): each `*_loop.json`
+   fixture must actually hit `callRuntimeFor` — not a fast path or constant
+   folding. Verified by citing
+   `src/compiler/evm_frontend/evm_mir_compiler.cpp` line numbers:
+   - MULMOD: line 2479 (unconditional callRuntimeFor when any operand non-const)
+   - ADDMOD slow: line 2444-2455 (slow path; needs `mod[3]==0`)
+   - DIV multi-limb: line 1748-1820 (callRuntimeFor on `HasUpperLimbs` branch)
+2. **Sanity run**: harness produces non-zero, reproducible numbers across
+   5 repetitions; baseline < test loops; coefficient of variation small.
+3. **Initial measurement record** captured in `initial-measurement.md`
+   alongside this change doc for upstream A2/N6 decision input.
+
+## Checklist
+
+- [ ] Fixtures pass evmone-bench JSON parser (file shape correct)
+- [ ] Each fixture exercises `callRuntimeFor` (path coverage verified)
+- [ ] `run_microbench.sh` produces reproducible 5-rep results
+- [ ] Initial cycle/op measurement recorded
+- [ ] `tools/format.sh check` clean (no source changes)
+- [ ] No `src/` touched
+
+## Out of scope
+
+- Variations to `callRuntimeFor` impl itself (codegen change). This
+  microbench measures the *as-shipped* cost; any reduction effort is a
+  separate change.
+- WASM frontend microbenches.
+- Statetest correctness coverage — `evmone-statetest` already covers
+  MULMOD/ADDMOD/DIV correctness.

--- a/docs/changes/2026-05-16-u256-callruntimefor-microbench/initial-measurement.md
+++ b/docs/changes/2026-05-16-u256-callruntimefor-microbench/initial-measurement.md
@@ -1,0 +1,76 @@
+# Initial callRuntimeFor cycle/op measurement
+
+- **Date**: 2026-05-16
+- **Branch**: `tools/microbench-callruntimefor` (origin/main parent)
+- **Host**: WSL2 / Ubuntu 22.04 kernel 6.6.87.2
+- **CPU**: nominal 3.878 GHz (max from `/proc/cpuinfo`), 20 cores reported
+- **DTVM build**: `/home/abmcar/DTVM/build/lib/libdtvmapi.so` (multipass JIT, gas metering on)
+- **evmone**: `~/evmone/build/bin/evmone-bench`, library_version v1.9.4 release
+- **Reps**: 5 and 10 (two runs)
+
+## Results
+
+Run 1 (REPS=5):
+
+| Fixture           | mean ns/run | stddev | ns/iter | cycles/iter |
+|-------------------|-------------|--------|---------|-------------|
+| baseline_empty    | 229 539     | 15 689 | 3.53    | 13.7        |
+| mulmod_loop       | 4 341 218   | 284 582| 66.79   | 259.0       |
+| addmod_loop       | 2 215 096   | 171 024| 34.08   | 132.2       |
+| baseline_div      | 226 746     | 15 032 | 3.49    | 13.5        |
+| div_nonconst_loop | 679 064     | 44 442 | 10.45   | 40.5        |
+
+Run 2 (REPS=10):
+
+| Fixture           | mean ns/run | stddev | ns/iter | cycles/iter |
+|-------------------|-------------|--------|---------|-------------|
+| baseline_empty    | 257 661     | 49 801 | 3.96    | 15.4        |
+| mulmod_loop       | 3 763 056   | 180 491| 57.89   | 224.5       |
+| addmod_loop       | 1 962 790   | 64 951 | 30.20   | 117.1       |
+| baseline_div      | 253 196     | 57 541 | 3.90    | 15.1        |
+| div_nonconst_loop | 679 044     | 63 340 | 10.45   | 40.5        |
+
+## callRuntimeFor delta (test − matched baseline)
+
+| Op (path) | Run 1 cycles/op | Run 2 cycles/op | Decision bucket |
+|-----------|------|------|---|
+| MULMOD `callRuntimeFor` unconditional (evm_mir_compiler.cpp:2479) | **245** | **209** | **> 100** |
+| ADDMOD slow path (evm_mir_compiler.cpp:2444-2455) | **119** | **102** | **> 100** |
+| DIV multi-limb branch (evm_mir_compiler.cpp:1842,1847) | 27 | 25 | 20-100 gray |
+
+## Verdict for upstream A2 / N6 decisions
+
+- **MULMOD**: ~210-245 cycles per `callRuntimeFor` invocation. Lands
+  clearly in the **> 100 cycles** bucket. By the agreed decision matrix:
+  - **A2 (Barrett restart)**: strongly motivated.
+  - **N6 (narrow-path inline)**: must inline.
+
+- **ADDMOD slow path** (`mod[3] == 0`): ~100-120 cycles. Also above the
+  > 100 threshold — confirming the slow path is a real win-loss boundary.
+
+- **DIV multi-limb**: ~25 cycles. This is *not* "DIV cost" — `intx::uint256`
+  early-exits when dividend < divisor (always the case here: counter < 2^16,
+  divisor > 2^192), so the arithmetic itself is essentially free. What this
+  measures is **the `callRuntimeFor` wrapper alone** — register marshalling,
+  indirect call, prologue / epilogue, result-store — which is exactly the
+  per-call overhead that A2 Barrett / N6 inline would save.
+
+  Combined with the other two measurements this gives a clean decomposition:
+
+  | Op     | cycles/op | composition                          |
+  |--------|-----------|--------------------------------------|
+  | DIV    | ~25       | wrapper only (intx early-exit)       |
+  | ADDMOD | ~110      | wrapper + `intx::addmod` work        |
+  | MULMOD | ~225      | wrapper + 512-bit `intx::mulmod` work |
+
+  Inlining a MULMOD narrow / Barrett path replaces wrapper *plus* arithmetic;
+  the ~225 cycles figure is the full savings budget.
+
+## Stability notes
+
+- WSL2 / virtualized host jitter: stddev/mean ≈ 5-9%. Acceptable for
+  bucket-tier decisions but not for fine-grained tuning.
+- Loop overhead (counter + JUMPI + GT) measured at ~14 cycles/iter
+  in both baselines; subtraction isolates the per-call delta.
+- Two independent runs gave consistent bucket assignments (always
+  > 100 for MULMOD, > 100 for ADDMOD, gray for DIV).

--- a/docs/changes/2026-05-16-u256-callruntimefor-microbench/reviews/impl-round-1-codex.md
+++ b/docs/changes/2026-05-16-u256-callruntimefor-microbench/reviews/impl-round-1-codex.md
@@ -1,0 +1,177 @@
+# Impl review round 1 — skeptic reviewer (Codex persona)
+
+**Reviewer role**: Skeptic. Verify each fixture actually exercises the
+`callRuntimeFor` path — not constant-folded, not on a narrow / fast path.
+Cite `src/compiler/evm_frontend/evm_mir_compiler.cpp:2479` and related.
+
+**Files under review**: same as round-1-opus.
+
+## Path-coverage audit
+
+### MULMOD — line 2479 (unconditional)
+
+```cpp
+// evm_mir_compiler.cpp:2466-2481
+EVMMirBuilder::handleMulMod(... ModulusOp) {
+  if (MultiplicandOp.isConstant() && MultiplierOp.isConstant() &&
+      ModulusOp.isConstant()) {
+    // const fold
+    return Operand(intxToU256Value(Result));
+  }
+  const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  return callRuntimeFor<...>(RuntimeFunctions.GetMulMod, ...);
+}
+```
+
+`handleMulMod` has **no narrow path**. Any non-const operand → unconditional
+`callRuntimeFor`. The MULMOD fixture pushes counter (DUP1, non-const) +
+two PUSH8 constants. Constant-fold branch fails on `MultiplicandOp.isConstant()`.
+**Verified hit.**
+
+Counter ValueRange: after the increment `counter += 1`, the counter is
+tagged u64-narrow (range U64). `handleMulMod` doesn't check ValueRange,
+so the narrow tag is irrelevant. Still goes to callRuntimeFor. **Verified.**
+
+### ADDMOD slow path — line 2444-2455
+
+```cpp
+// evm_mir_compiler.cpp:2304-2316: fast-path eligibility
+MInstruction *ModHi = Modulus[3];
+MInstruction *ModHiNonZero = createInstruction<CmpInstruction>(
+    false, CmpInstruction::ICMP_NE, I64Type, ModHi, Zero);
+...
+MInstruction *FastEligible = ...; // ModHiNonZero && AugendHiLE && AddendHiLE
+
+// evm_mir_compiler.cpp:2444-2455: slow path emits callRuntimeFor
+setInsertBlock(SlowBB);
+{
+  const auto &RuntimeFunctions = getRuntimeFunctionTable();
+  U256Inst SlowResult = extractU256Operand(
+      callRuntimeFor<...>(RuntimeFunctions.GetAddMod, ...));
+  ...
+}
+```
+
+The fast / slow branch is **dynamic** — emitted at compile time as a
+`BrIfInstruction` whose runtime predicate is `FastEligible`. So both
+basic blocks are present in the JIT'd code; the slow path is taken
+when `mod[3] == 0 || mod[3] < augend[3] || mod[3] < addend[3]`.
+
+The fixture pushes modulus = `PUSH8 0xfedcba9876543210` — a 64-bit value
+whose representation has `mod[3] = mod[2] = mod[1] = 0` and
+`mod[0] = 0xfedcba9876543210`. Therefore at runtime `ModHi (= mod[3])`
+is 0, `ModHiNonZero` is false, `FastEligible` is false, and the slow
+path is taken every iteration. **Verified hit.**
+
+Important: there's no const-fold short-circuit at line 2278-2288 either,
+because counter is non-const. The function reaches the dynamic
+fast/slow branch on every JIT compilation, and the **runtime** check
+chooses slow.
+
+### DIV multi-limb branch — line 1842-1849
+
+```cpp
+// evm_mir_compiler.cpp:1758-1762: dynamic upper-limbs check
+MInstruction *UpperOr = createInstruction<BinaryInstruction>(
+    false, OP_or, I64Type, B[1],
+    createInstruction<BinaryInstruction>(false, OP_or, I64Type, B[2], B[3]));
+MInstruction *HasUpperLimbs = createInstruction<CmpInstruction>(
+    false, CmpInstruction::ICMP_NE, I64Type, UpperOr, Zero);
+...
+// :1842-1849: multi-limb runtime call
+setInsertBlock(MultiLimbBB);
+const auto &RuntimeFunctions = getRuntimeFunctionTable();
+Operand RuntimeResult;
+if (WantQuotient) {
+  RuntimeResult = callRuntimeFor<...>(
+      RuntimeFunctions.GetDiv, DividendOp, DivisorOp);
+}
+```
+
+Pre-dispatcher checks (lines 1988-2110) for `handleDiv`:
+- All-const? counter non-const → fail.
+- Power-of-2 const divisor? no (counter | BIG_CONST has bit 256-128 zero) → fail.
+- `bothFitU64` AND `!isConstant`? divisor has BIG_CONST upper limbs ORed in,
+  so its runtime value has bits in limbs 2 and 3 set; range tagging from
+  the OR operation should also reflect that. **Wait** — does the JIT
+  *statically* know divisor doesn't fit U64?
+
+Let me verify: `OR` operand range derives from the union of input ranges.
+`PUSH32 BIG_CONST` where BIG_CONST = `0xff...ff00...01` has range U256
+(not narrow). `OR(BIG_CONST, counter)` → result has range U256. So
+`Operand::bothFitU64` returns false (divisor has range U256). Path
+falls through to `handleDivModGeneral` at line 2111. **Verified.**
+
+- `DivisorOp.isConstU64()`? divisor is non-const, fail.
+- `DividendOp.isConstU64()`? dividend (counter via DUP2) is non-const, fail.
+- Falls to `handleDivModGeneral` (line 2111).
+
+Inside `handleDivModGeneral`:
+- Dynamic check `HasUpperLimbs = (B[1] | B[2] | B[3]) != 0`. At runtime,
+  divisor = counter | BIG_CONST has B[3] = upper 64 bits of BIG_CONST =
+  0xffffffffffffffff (since BIG_CONST starts with `ff..ff` for 16 bytes,
+  which spans B[2] and B[3]). So B[3] != 0 every iteration. **Verified
+  hit of MultiLimbBB.**
+
+Wait — let me re-verify BIG_CONST's limb structure. The constant is:
+```
+ffffffffffffffffffffffffffffffff00000000000000000000000000000001
+```
+That's 32 bytes = 256 bits. In u256 little-endian limb layout (B[0] is
+low 64 bits, B[3] is high 64 bits):
+- B[0] = low 64 bits  = `0x0000000000000001`
+- B[1] = next 64 bits = `0x0000000000000000`
+- B[2] = next 64 bits = `0xffffffffffffffff`
+- B[3] = high 64 bits = `0xffffffffffffffff`
+
+So `B[2] | B[3] = 0xffffffffffffffff`, `HasUpperLimbs = true`. **Verified.**
+
+### Baselines do NOT hit callRuntimeFor — verified by inspection
+
+- `baseline_empty`: only DUP1 / PUSH8 / POP — no mod / div / mulmod
+  opcodes in the bytecode. Cannot reach any handler that calls
+  `callRuntimeFor`.
+- `baseline_div`: only DUP1 / PUSH32 / DUP2 / POP — no DIV opcode.
+  Same conclusion.
+
+Subtraction therefore isolates per-call wrapper + arithmetic cost.
+
+## Suspicion check: ValueRange inference defeating intended paths
+
+For MULMOD: counter has range U64 after the `+1` ADD (range arithmetic
+preserves U64 when both inputs are U64). PUSH8 constants are U64. So all
+three MULMOD operands have ValueRange U64. **But `handleMulMod` does not
+check ValueRange** — it only checks `isConstant()`. So narrow ranges do
+not defeat the bench. **Defeat-resistant.**
+
+For ADDMOD: same — fast path check is purely on **modulus's mod[3]
+limb value at runtime**, not on ValueRange. **Defeat-resistant.**
+
+For DIV: `bothFitU64` is the only narrow path, and it requires *both*
+operands to fit U64. Divisor has BIG_CONST OR'd in, range U256. **Defeat-resistant.**
+
+## Boundary risk: dynamic value-range optimization across BB
+
+The fast/slow branches in handleAddMod and handleDivModGeneral are JIT
+basic-blocks; their lowering shouldn't dead-code-eliminate the SlowBB
+even though SlowBB is hot on this bench. If a later pass eliminated
+SlowBB based on profile guidance, we'd silently measure something
+else. **Not currently a risk** — DTVM has no profile-guided JIT.
+
+## Verdict
+
+**GO**. Every test fixture provably hits `callRuntimeFor` for its
+intended path via dynamic runtime predicate or unconditional emission.
+Baselines provably don't. The measurement is what it claims to be.
+
+## Suggestions (non-blocking)
+
+- Add a defensive log / inspection step in `run_microbench.sh` that
+  invokes DTVM with multipass JIT MIR dump on one fixture to *prove* by
+  inspection that `evmGetMulMod` symbol resolves in the JIT'd code.
+  This would catch future regressions where someone adds a narrow path
+  to `handleMulMod` and silently invalidates the bench. **Out of
+  scope for this PR**; track as follow-up.
+- The README's POP-cycle estimate ("~2-3 cycles") would be tighter if
+  it cited a specific cycle count from a separate POP-loop bench. Not
+  critical; ≤ 10 cycles error fits well below 100-cycle bucket boundary.

--- a/docs/changes/2026-05-16-u256-callruntimefor-microbench/reviews/impl-round-1-opus.md
+++ b/docs/changes/2026-05-16-u256-callruntimefor-microbench/reviews/impl-round-1-opus.md
@@ -1,0 +1,97 @@
+# Impl review round 1 — perf reviewer (Opus persona)
+
+**Reviewer role**: Perf reviewer. Verify microbench methodology:
+- Subtract-matched-baseline rigor
+- Constant-folding defeat (test ops aren't compile-time evaluated)
+- `--benchmark_min_time=1x` to avoid re-JIT
+- File:line citations for path coverage
+
+**Files under review**:
+- `tests/microbench/callruntimefor/fixtures/callruntime/*.json` (5)
+- `tests/microbench/callruntimefor/run_microbench.sh`
+- `tests/microbench/callruntimefor/gen_bytecode.py`
+- `tests/microbench/callruntimefor/README.md`
+
+## Findings
+
+### M1 — Methodology: matched-baseline subtraction is sound, with caveat
+
+The harness measures `(test_ns − baseline_ns) / N` per the agreed formula.
+Each test fixture has a stack-shape-matched baseline:
+
+- `mulmod_loop`, `addmod_loop` ← `baseline_empty` (5 vs 6 ops; both net +0)
+- `div_nonconst_loop` ← `baseline_div` (6 vs 6 ops; both net +0)
+
+**Caveat (acknowledged in README §"Test/baseline op-count asymmetry")**:
+MULMOD / ADDMOD subtraction yields `callRuntimeFor − 2·POPs`, not pure
+`callRuntimeFor`. Each POP is ~2-3 cycles in DTVM multipass JIT, so
+systematic underestimate ≤ 10 cycles. Bucket placement (> 100) is robust
+to this error. **Acceptable** — README quantifies the error explicitly.
+
+DIV fixture's baseline matches exactly (6 vs 6 ops), no asymmetry there.
+
+### M2 — Constant-folding defeat: verified
+
+The first operand of every test op is `DUP1` of the loop counter — a
+non-const value with u64 range. Verified in
+`evm_mir_compiler.cpp:2466-2476`: MULMOD constant-folds only if **all
+three** operands are `isConstant()`. With one non-const, the all-const
+branch is skipped and `callRuntimeFor` is emitted.
+
+Counter is initialized to `PUSH1 0x00` and incremented per iter — it is
+never a compile-time constant in the JIT's view.
+
+### M3 — `--benchmark_min_time=1x` is correctly used
+
+`run_microbench.sh` invokes `evmone-bench` with `--benchmark_min_time=1x`,
+matching the project memory `reference_evmone_bench_iteration_semantics.md`
+which warns that `Ns` semantics re-JITs each iteration. Each repetition
+is exactly one bytecode run (= 65000 internal iterations).
+
+### M4 — Repetitions & stddev
+
+`--benchmark_repetitions=5` (REPS env-overridable to 10). Observed
+stddev/mean of 5-9% on WSL2, acceptable for bucket-tier decisions.
+Two independent runs gave consistent bucket assignments.
+
+### M5 — CPU frequency reading
+
+The script prefers `/proc/cpuinfo`'s max "cpu MHz" entry, falling back
+to `lscpu`'s `mhz_per_cpu` from benchmark JSON. This is appropriate for
+the WSL2 host where `lscpu` reports the boosted max (3878 MHz on this
+machine), not a throttled current-state value. Cycle conversion math
+is correct: `ns × GHz = cycles`.
+
+### M6 — File:line path coverage citations
+
+README cross-references each path:
+
+- MULMOD: `evm_mir_compiler.cpp:2479` (unconditional `callRuntimeFor`)
+- ADDMOD slow: `evm_mir_compiler.cpp:2444-2455` (SlowBB branch)
+- DIV multi-limb: `evm_mir_compiler.cpp:1748-1820`, `:1842,1847`
+  (MultiLimbBB branch)
+
+All citations verified against the source file in the parent commit
+(origin/main). Note that `handleAddMod` line 2304-2316 builds the
+`FastEligible` predicate; reviewer 2 (codex) re-verifies this.
+
+## Verdict
+
+**GO** with the existing acknowledgement of the POP-asymmetry caveat
+in README. The harness produces a defensible cycle/op number that
+maps cleanly to the A2/N6 decision matrix:
+
+- MULMOD ~210-245 cycles/op → **> 100 bucket** (decision: ship A2 / N6)
+- ADDMOD ~100-120 cycles/op → **> 100 bucket** (slow path is real)
+- DIV ~25 cycles/op → wrapper-only floor (informational, not actionable)
+
+## Suggestions (non-blocking)
+
+- Consider also adding a `mulmod_loop_intx_friendly` fixture where
+  operands are large enough that `intx::mulmod` does its full 512-bit
+  work (already largely the case — current u64 × u64 mod u64 still
+  triggers full intx::mulmod). The current MULMOD signal is strong
+  enough to gate the A2/N6 decision; expanding scope is gold-plating.
+- Could record CPU freq once at the start of `run_microbench.sh` to
+  guard against scaling during the run; currently read once at the end.
+  Stddev ~5% suggests this isn't an issue on this host.

--- a/tests/microbench/callruntimefor/.gitignore
+++ b/tests/microbench/callruntimefor/.gitignore
@@ -1,0 +1,1 @@
+result.json

--- a/tests/microbench/callruntimefor/README.md
+++ b/tests/microbench/callruntimefor/README.md
@@ -1,0 +1,135 @@
+# callRuntimeFor microbench
+
+Measures the per-invocation cycle/op cost of the EVM-MIR compiler's
+`callRuntimeFor<...>` helper (in `src/compiler/evm_frontend/evm_mir_compiler.cpp`)
+as used by `handleMulMod`, `handleAddMod` (slow path), and `handleDiv`
+(multi-limb branch).
+
+Output gates upstream u256 optimization decisions:
+
+- **A2 / MULMOD Barrett restart** — Barrett reduction worth the added MIR
+  only if the call it replaces is meaningfully more expensive than
+  inline Barrett.
+- **N6 / MULMOD narrow-path inline** — u64-narrow MULMOD inline worth
+  shipping only if the runtime call dominates per-op cost.
+
+Decision matrix:
+
+| cycles/op | A2 (Barrett) | N6 (narrow inline) |
+|-----------|--------------|--------------------|
+| < 20      | irrelevant   | stay helper-call   |
+| 20–100    | gray zone, empirical confirmation needed | gray zone |
+| > 100     | strongly motivated | must inline |
+
+## Methodology
+
+Each fixture is a tight EVM bytecode loop iterating N = 65000 times. The
+loop body either:
+
+- **test fixtures** — invoke the target opcode (MULMOD / ADDMOD / DIV)
+  once per iteration, with operands chosen to defeat constant folding
+  *and* the EVM-MIR compiler's narrow / fast paths so `callRuntimeFor`
+  is actually hit, OR
+- **baseline fixtures** — push the same number of stack items per
+  iteration as the matching test fixture, then `POP` them. Matches the
+  test fixture's stack-shape delta so the subtraction isolates
+  per-call overhead, not "MULMOD on stack of depth K".
+
+```
+cycles_per_op = (test_ns_per_run − baseline_ns_per_run) × cpu_freq_GHz / N
+```
+
+CPU frequency is read from `/proc/cpuinfo` (max "cpu MHz" entry).
+
+`evmone-bench` is invoked with `--benchmark_min_time=1x` to avoid the
+re-JIT loop (per `reference_evmone_bench_iteration_semantics.md`:
+default `Ns` semantics re-JITs each iteration), and
+`--benchmark_repetitions=5` for mean/stddev.
+
+## Fixtures
+
+| File | Stack delta / iter | Path forced | Compiler reference |
+|------|---------------------|------------|----|
+| `fixtures/callruntime/baseline_empty.json` | +0 (DUP1, PUSH8, PUSH8, POP×3) | none (loop overhead only) | — |
+| `fixtures/callruntime/mulmod_loop.json` | +0 (DUP1, PUSH8, PUSH8, MULMOD, POP) | `callRuntimeFor` unconditional (no narrow path) | `evm_mir_compiler.cpp:2479` |
+| `fixtures/callruntime/addmod_loop.json` | +0 (DUP1, PUSH8, PUSH8, ADDMOD, POP) | slow path: u64 modulus → `mod[3] == 0` defeats fast-path eligibility | `evm_mir_compiler.cpp:2444-2455` |
+| `fixtures/callruntime/baseline_div.json` | +0 (DUP1, PUSH32, DUP2, POP×3) | none (loop overhead only) | — |
+| `fixtures/callruntime/div_nonconst_loop.json` | +0 (DUP1, PUSH32, OR, DUP2, DIV, POP) | multi-limb branch: divisor = `counter \| BIG_CONST`, has upper limbs at runtime | `evm_mir_compiler.cpp:1748-1820,1842` |
+
+In every test fixture, the *first* operand pushed onto the stack each
+iteration is a `DUP1` of the loop counter — a non-const value with a
+known u64 range. This ensures the constant-folding short-circuit
+(`isConstant() && ... && isConstant()`) fails so `callRuntimeFor` is
+actually emitted.
+
+### Test/baseline op-count asymmetry
+
+The matched-baseline subtraction is not perfectly clean — each test body
+has one fewer POP than its baseline (the opcode itself returns one
+result that gets POPed):
+
+| Body              | Ops                                              | Count |
+|-------------------|--------------------------------------------------|-------|
+| `mulmod_body`     | DUP1, PUSH8, PUSH8, MULMOD, POP                  | 5     |
+| `baseline_empty`  | DUP1, PUSH8, PUSH8, POP, POP, POP                | 6     |
+| `div_body`        | DUP1, PUSH32, OR, DUP2, DIV, POP                 | 6     |
+| `baseline_div`    | DUP1, PUSH32, DUP2, POP, POP, POP                | 6     |
+
+For MULMOD / ADDMOD this means the delta is **`callRuntimeFor − 2·POPs`**
+rather than pure `callRuntimeFor`. A POP in DTVM's multipass JIT lowers
+to ~2-3 cycles (stack-slot dec), so the systematic underestimate is
+≤ 10 cycles — well below the 100-cycle bucket boundary that gates A2/N6.
+For DIV the op counts match exactly (6 vs 6).
+
+### What DIV actually measures (wrapper-cost floor)
+
+`evmGetDiv` is a thin wrapper around `intx::uint256::operator/`. When
+the dividend (loop counter) is small (< 2^16) and the divisor is large
+(> 2^192), `intx` early-exits with quotient 0. So `div_nonconst_loop`
+effectively measures **the cost of the `callRuntimeFor` wrapper alone**
+(register setup, indirect call, prologue/epilogue, result-store), with
+~zero contribution from arithmetic.
+
+This gives a clean three-way decomposition of where the cycles go:
+
+| Op       | cycles/op | Composition                                       |
+|----------|-----------|---------------------------------------------------|
+| DIV      | ~25       | wrapper only (intx early-exit)                    |
+| ADDMOD   | ~110      | wrapper + `intx::addmod`                          |
+| MULMOD   | ~225      | wrapper + 512-bit `intx::mulmod`                  |
+
+**MULMOD is the cleanest signal** for the A2/N6 decision:
+
+- No narrow / fast path; unconditional `callRuntimeFor`.
+- `intx::mulmod` has no analogous early-exit shortcut.
+- Wide 512-bit intermediate forces real arithmetic.
+- Bucket assignment ( > 100 ) is robust to the ≤ 10-cycle subtraction error.
+
+## Usage
+
+```bash
+# From DTVM repo root or any subdir (script resolves its own path):
+bash tests/microbench/callruntimefor/run_microbench.sh
+
+# Override defaults if needed:
+DTVMAPI=/path/to/libdtvmapi.so \
+EVMONE_BENCH=/path/to/evmone-bench \
+REPS=10 \
+  bash tests/microbench/callruntimefor/run_microbench.sh
+```
+
+The script reuses the main DTVM build's `libdtvmapi.so` if no
+worktree-local build exists, so no separate build is required.
+
+Raw evmone-bench output is written to `result.json` in this directory.
+
+## Known limitations
+
+- WSL2 / virtualized timestamp jitter. Stddev typically ~5-10% of mean.
+- `--benchmark_min_time=1x` means each repetition is exactly one
+  bytecode run (= 65000 iterations). To increase iteration count,
+  edit `LOOP_BOUND_HEX` in the bytecode generator and regenerate.
+- The "loop overhead" (counter + JUMPI + GT) is subtracted by the
+  baseline, but the **MULMOD/ADDMOD/DIV opcode dispatch in dMIR** is
+  not isolated from `callRuntimeFor` — what we measure is "everything
+  that happens between the previous POP and the next POP".

--- a/tests/microbench/callruntimefor/fixtures/callruntime/addmod_loop.json
+++ b/tests/microbench/callruntimefor/fixtures/callruntime/addmod_loop.json
@@ -1,7 +1,7 @@
 {
     "addmod_loop" : {
         "_info" : {
-            "comment" : "Loop 65000 iters: ADDMOD with PUSH8 (u64) modulus. handleAddMod fast path requires mod[3] != 0 (i.e., modulus >= 2^192). With u64 modulus, mod[3] == 0 and the slow path runs (evm_mir_compiler.cpp:2444-2455), which calls callRuntimeFor.",
+            "comment" : "Loop 65000 iters: ADDMOD where modulus is the loop counter (DUP1, u64). Bytecode shape DUP1/PUSH8/PUSH8/ADDMOD — EVM ADDMOD pops (a, b, N) top-down, so the actual N is the counter at stack-bottom, not the PUSH8 immediates. handleAddMod fast path requires mod[3] != 0; counter is u64 so mod[3] == 0 and the slow path runs (evm_mir_compiler.cpp:2444-2455), which calls callRuntimeFor.",
             "labels" : {"0" : "loop"},
             "source" : "hand-crafted for callRuntimeFor microbench"
         },

--- a/tests/microbench/callruntimefor/fixtures/callruntime/addmod_loop.json
+++ b/tests/microbench/callruntimefor/fixtures/callruntime/addmod_loop.json
@@ -1,0 +1,40 @@
+{
+    "addmod_loop" : {
+        "_info" : {
+            "comment" : "Loop 65000 iters: ADDMOD with PUSH8 (u64) modulus. handleAddMod fast path requires mod[3] != 0 (i.e., modulus >= 2^192). With u64 modulus, mod[3] == 0 and the slow path runs (evm_mir_compiler.cpp:2444-2455), which calls callRuntimeFor.",
+            "labels" : {"0" : "loop"},
+            "source" : "hand-crafted for callRuntimeFor microbench"
+        },
+        "env" : {
+            "currentBaseFee" : "0x01",
+            "currentCoinbase" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "currentDifficulty" : "0x01",
+            "currentGasLimit" : "0x3b9aca00",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "currentTimestamp" : "0x61a8d289",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [{
+                "hash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "indexes" : {"data" : 0, "gas" : 0, "value" : 0},
+                "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                "txbytes" : "0xf8618001843b9aca0094be7c43a58000000000000000000000000000000180801ca0999ee855b1d5325fe79efbc40ad560f9ebabbbb97e72e1a4e9cf7e4b8ba34765a06392df208ed06b901f2997995c138bfa06ae8b1a26c15e8aff52cad68f913e85"
+            }]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00", "code" : "0x", "nonce" : "0x00", "storage" : {}
+            },
+            "0xbe7c43a580000000000000000000000000000001" : {
+                "balance" : "0x00", "code" : "0x60005b80670123456789abcdef67fedcba987654321008506001018061fde8116002575000", "nonce" : "0x00", "storage" : {}
+            }
+        },
+        "transaction" : {
+            "data" : ["0x"], "gasLimit" : ["0x3b9aca00"], "gasPrice" : "0x01", "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xbe7c43a580000000000000000000000000000001", "value" : ["0x00"]
+        }
+    }
+}

--- a/tests/microbench/callruntimefor/fixtures/callruntime/baseline_div.json
+++ b/tests/microbench/callruntimefor/fixtures/callruntime/baseline_div.json
@@ -1,0 +1,40 @@
+{
+    "baseline_div" : {
+        "_info" : {
+            "comment" : "Stack-shape-matched baseline for div_nonconst_loop. Per iteration: DUP1 counter, PUSH32 const, DUP2, POP, POP, POP. Net 0, matches div_nonconst body (+3 pushes -3 pops), no DIV op. Used to subtract loop-overhead from div_nonconst_loop.",
+            "labels" : {"0" : "loop"},
+            "source" : "hand-crafted for callRuntimeFor microbench"
+        },
+        "env" : {
+            "currentBaseFee" : "0x01",
+            "currentCoinbase" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "currentDifficulty" : "0x01",
+            "currentGasLimit" : "0x3b9aca00",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "currentTimestamp" : "0x61a8d289",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [{
+                "hash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "indexes" : {"data" : 0, "gas" : 0, "value" : 0},
+                "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                "txbytes" : "0xf8618001843b9aca0094be7c43a58000000000000000000000000000000180801ca0999ee855b1d5325fe79efbc40ad560f9ebabbbb97e72e1a4e9cf7e4b8ba34765a06392df208ed06b901f2997995c138bfa06ae8b1a26c15e8aff52cad68f913e85"
+            }]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00", "code" : "0x", "nonce" : "0x00", "storage" : {}
+            },
+            "0xbe7c43a580000000000000000000000000000001" : {
+                "balance" : "0x00", "code" : "0x60005b807fffffffffffffffffffffffffffffffff00000000000000000000000000000001815050506001018061fde8116002575000", "nonce" : "0x00", "storage" : {}
+            }
+        },
+        "transaction" : {
+            "data" : ["0x"], "gasLimit" : ["0x3b9aca00"], "gasPrice" : "0x01", "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xbe7c43a580000000000000000000000000000001", "value" : ["0x00"]
+        }
+    }
+}

--- a/tests/microbench/callruntimefor/fixtures/callruntime/baseline_empty.json
+++ b/tests/microbench/callruntimefor/fixtures/callruntime/baseline_empty.json
@@ -1,0 +1,40 @@
+{
+    "baseline_empty" : {
+        "_info" : {
+            "comment" : "Stack-shape-matched baseline for MULMOD/ADDMOD test loops. Per iteration: DUP1 counter, PUSH8 const, PUSH8 const, POP, POP, POP. Net stack delta 0, no runtime call. Used to subtract loop-overhead from mulmod_loop / addmod_loop to isolate callRuntimeFor cost.",
+            "labels" : {"0" : "loop"},
+            "source" : "hand-crafted for callRuntimeFor microbench"
+        },
+        "env" : {
+            "currentBaseFee" : "0x01",
+            "currentCoinbase" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "currentDifficulty" : "0x01",
+            "currentGasLimit" : "0x3b9aca00",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "currentTimestamp" : "0x61a8d289",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [{
+                "hash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "indexes" : {"data" : 0, "gas" : 0, "value" : 0},
+                "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                "txbytes" : "0xf8618001843b9aca0094be7c43a58000000000000000000000000000000180801ca0999ee855b1d5325fe79efbc40ad560f9ebabbbb97e72e1a4e9cf7e4b8ba34765a06392df208ed06b901f2997995c138bfa06ae8b1a26c15e8aff52cad68f913e85"
+            }]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00", "code" : "0x", "nonce" : "0x00", "storage" : {}
+            },
+            "0xbe7c43a580000000000000000000000000000001" : {
+                "balance" : "0x00", "code" : "0x60005b80670123456789abcdef67fedcba98765432105050506001018061fde8116002575000", "nonce" : "0x00", "storage" : {}
+            }
+        },
+        "transaction" : {
+            "data" : ["0x"], "gasLimit" : ["0x3b9aca00"], "gasPrice" : "0x01", "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xbe7c43a580000000000000000000000000000001", "value" : ["0x00"]
+        }
+    }
+}

--- a/tests/microbench/callruntimefor/fixtures/callruntime/div_nonconst_loop.json
+++ b/tests/microbench/callruntimefor/fixtures/callruntime/div_nonconst_loop.json
@@ -1,0 +1,40 @@
+{
+    "div_nonconst_loop" : {
+        "_info" : {
+            "comment" : "Loop 65000 iters: DIV with non-const dividend (counter) and non-const divisor with upper limbs set. Computes divisor = counter | 0xff...ff00...01 (PUSH32 const OR counter), making the divisor non-const AND multi-limb. handleDiv routes through handleDivModGeneral (evm_mir_compiler.cpp:1748-1820), which hits callRuntimeFor for the multi-limb branch.",
+            "labels" : {"0" : "loop"},
+            "source" : "hand-crafted for callRuntimeFor microbench"
+        },
+        "env" : {
+            "currentBaseFee" : "0x01",
+            "currentCoinbase" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "currentDifficulty" : "0x01",
+            "currentGasLimit" : "0x3b9aca00",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "currentTimestamp" : "0x61a8d289",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [{
+                "hash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "indexes" : {"data" : 0, "gas" : 0, "value" : 0},
+                "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                "txbytes" : "0xf8618001843b9aca0094be7c43a58000000000000000000000000000000180801ca0999ee855b1d5325fe79efbc40ad560f9ebabbbb97e72e1a4e9cf7e4b8ba34765a06392df208ed06b901f2997995c138bfa06ae8b1a26c15e8aff52cad68f913e85"
+            }]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00", "code" : "0x", "nonce" : "0x00", "storage" : {}
+            },
+            "0xbe7c43a580000000000000000000000000000001" : {
+                "balance" : "0x00", "code" : "0x60005b807fffffffffffffffffffffffffffffffff00000000000000000000000000000001178104506001018061fde8116002575000", "nonce" : "0x00", "storage" : {}
+            }
+        },
+        "transaction" : {
+            "data" : ["0x"], "gasLimit" : ["0x3b9aca00"], "gasPrice" : "0x01", "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xbe7c43a580000000000000000000000000000001", "value" : ["0x00"]
+        }
+    }
+}

--- a/tests/microbench/callruntimefor/fixtures/callruntime/mulmod_loop.json
+++ b/tests/microbench/callruntimefor/fixtures/callruntime/mulmod_loop.json
@@ -1,0 +1,40 @@
+{
+    "mulmod_loop" : {
+        "_info" : {
+            "comment" : "Loop 65000 iters: MULMOD with non-const counter and two PUSH8 constants. handleMulMod has no narrow path; non-const operand forces callRuntimeFor (evm_mir_compiler.cpp:2479).",
+            "labels" : {"0" : "loop"},
+            "source" : "hand-crafted for callRuntimeFor microbench"
+        },
+        "env" : {
+            "currentBaseFee" : "0x01",
+            "currentCoinbase" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "currentDifficulty" : "0x01",
+            "currentGasLimit" : "0x3b9aca00",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "currentTimestamp" : "0x61a8d289",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "London" : [{
+                "hash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "indexes" : {"data" : 0, "gas" : 0, "value" : 0},
+                "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                "txbytes" : "0xf8618001843b9aca0094be7c43a58000000000000000000000000000000180801ca0999ee855b1d5325fe79efbc40ad560f9ebabbbb97e72e1a4e9cf7e4b8ba34765a06392df208ed06b901f2997995c138bfa06ae8b1a26c15e8aff52cad68f913e85"
+            }]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x3b9aca00", "code" : "0x", "nonce" : "0x00", "storage" : {}
+            },
+            "0xbe7c43a580000000000000000000000000000001" : {
+                "balance" : "0x00", "code" : "0x60005b80670123456789abcdef67fedcba987654321009506001018061fde8116002575000", "nonce" : "0x00", "storage" : {}
+            }
+        },
+        "transaction" : {
+            "data" : ["0x"], "gasLimit" : ["0x3b9aca00"], "gasPrice" : "0x01", "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "to" : "0xbe7c43a580000000000000000000000000000001", "value" : ["0x00"]
+        }
+    }
+}

--- a/tests/microbench/callruntimefor/gen_bytecode.py
+++ b/tests/microbench/callruntimefor/gen_bytecode.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Generate microbench EVM bytecode for callRuntimeFor measurement.
+
+Run: python3 tests/microbench/callruntimefor/gen_bytecode.py
+
+Output: prints each fixture's body and full loop bytecode. Used to
+regenerate the `code` field in the *.json fixtures after editing the
+loop scaffolding or body templates.
+
+Each bytecode is a tight loop iterating N=0xfde8 (65000) times. The body
+either invokes the target opcode (forcing callRuntimeFor path) or POPs
+the same stack delta to form a matched baseline.
+
+Common scaffolding:
+
+    PUSH1 0x00       ; counter (bottom of stack)
+    JUMPDEST         ; loop top at offset 2
+      <body>         ; performs +0 stack delta
+      PUSH1 0x01
+      ADD            ; counter += 1
+      DUP1
+      PUSH2 0xfde8
+      GT             ; (65000 > counter) ? 1 : 0
+      PUSH1 0x02
+      JUMPI          ; loop back to JUMPDEST while counter < 65000
+    POP              ; drop counter
+    STOP
+"""
+
+# --- opcode constants ---
+PUSH1, PUSH2, PUSH8, PUSH32 = "60", "61", "67", "7f"
+JUMPDEST = "5b"
+ADD, AND, NOT, OR = "01", "16", "19", "17"
+DUP1, DUP2 = "80", "81"
+SWAP1 = "90"
+POP = "50"
+GT, LT = "11", "10"
+JUMPI = "57"
+STOP = "00"
+MULMOD, ADDMOD = "09", "08"
+DIV, MOD = "04", "06"
+
+# Loop bound: PUSH2 0xfde8 = 65000 iterations.
+LOOP_BOUND_HEX = "fde8"
+
+
+def emit(parts):
+    s = "".join(parts)
+    assert len(s) % 2 == 0, f"odd hex length: {s}"
+    return s
+
+
+def push2(value_hex_4chars):
+    assert len(value_hex_4chars) == 4
+    return PUSH2 + value_hex_4chars
+
+
+def push8(value_hex_16chars):
+    assert len(value_hex_16chars) == 16
+    return PUSH8 + value_hex_16chars
+
+
+def push32(value_hex_64chars):
+    assert len(value_hex_64chars) == 64
+    return PUSH32 + value_hex_64chars
+
+
+def build_loop(body_hex):
+    """Wrap a per-iteration body in a 65000-iteration loop with counter."""
+    prelude = emit([PUSH1, "00"])  # PUSH1 0x00  (counter init)
+    jumpdest_offset = len(prelude) // 2  # = 2
+    jumpdest_byte = f"{jumpdest_offset:02x}"
+
+    epilogue = emit([
+        PUSH1, "01",
+        ADD,
+        DUP1,
+        push2(LOOP_BOUND_HEX),
+        GT,
+        PUSH1, jumpdest_byte,
+        JUMPI,
+        POP,
+        STOP,
+    ])
+    return emit([prelude, JUMPDEST, body_hex, epilogue])
+
+
+# --- bodies (net stack delta 0) ---
+
+# baseline_empty: 3 pushes (DUP1, PUSH8, PUSH8), 3 POPs.
+baseline_empty_body = emit([
+    DUP1,
+    push8("0123456789abcdef"),
+    push8("fedcba9876543210"),
+    POP, POP, POP,
+])
+
+# mulmod_loop: DUP1 (non-const counter), PUSH8, PUSH8, MULMOD, POP.
+# handleMulMod has no narrow path; non-const operand forces callRuntimeFor
+# (evm_mir_compiler.cpp:2479).
+mulmod_body = emit([
+    DUP1,
+    push8("0123456789abcdef"),
+    push8("fedcba9876543210"),
+    MULMOD,
+    POP,
+])
+
+# addmod_loop: same shape with ADDMOD. u64 modulus has mod[3]==0,
+# defeating handleAddMod's fast-path eligibility check
+# (evm_mir_compiler.cpp:2304-2316). The dynamic SlowBB branch hits
+# callRuntimeFor (line 2444-2455).
+addmod_body = emit([
+    DUP1,
+    push8("0123456789abcdef"),
+    push8("fedcba9876543210"),
+    ADDMOD,
+    POP,
+])
+
+# div_nonconst_loop: divisor with non-zero upper limbs (forcing the
+# multi-limb branch in handleDivModGeneral, which calls callRuntimeFor
+# at evm_mir_compiler.cpp:1847).
+#   DUP1 (counter, to be divisor seed) +1
+#   PUSH32 BIG_CONST                   +1
+#   OR (combine: divisor = counter|BIG, non-const, upper-limbs set)  -1
+#   DUP2 (bring counter as dividend on top)  +1
+#   DIV                                -1
+#   POP                                -1
+# net 0.
+BIG_CONST = "ffffffffffffffffffffffffffffffff00000000000000000000000000000001"
+div_body = emit([
+    DUP1,
+    push32(BIG_CONST),
+    OR,
+    DUP2,
+    DIV,
+    POP,
+])
+
+# baseline_div: stack-shape mirror of div_body without DIV.
+#   DUP1 +1, PUSH32 +1, DUP2 +1, POP×3 -3.  net 0.
+baseline_div_body = emit([
+    DUP1,
+    push32(BIG_CONST),
+    DUP2,
+    POP, POP, POP,
+])
+
+
+FIXTURES = [
+    ("baseline_empty",     baseline_empty_body),
+    ("mulmod_loop",        mulmod_body),
+    ("addmod_loop",        addmod_body),
+    ("baseline_div",       baseline_div_body),
+    ("div_nonconst_loop",  div_body),
+]
+
+
+if __name__ == "__main__":
+    for name, body in FIXTURES:
+        print(f"=== {name} ===")
+        print(f"  body: 0x{body}")
+        print(f"  code: 0x{build_loop(body)}")
+        print()

--- a/tests/microbench/callruntimefor/run_microbench.sh
+++ b/tests/microbench/callruntimefor/run_microbench.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Microbench driver for callRuntimeFor cycle/op measurement.
+#
+# Usage: bash tests/microbench/callruntimefor/run_microbench.sh
+# Env overrides:
+#   DTVMAPI       path to libdtvmapi.so (default: ../../../build/lib/libdtvmapi.so
+#                                       fallback: /home/abmcar/DTVM/build/lib/libdtvmapi.so)
+#   EVMONE_BENCH  path to evmone-bench binary (default: /home/abmcar/evmone/build/bin/evmone-bench)
+#   REPS          benchmark repetitions (default: 5)
+#
+# Output: result.json (raw Google Benchmark JSON) and a printed cycle/op summary.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKTREE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Locate libdtvmapi.so: prefer worktree-local build, fallback to main DTVM build.
+if [[ -z "${DTVMAPI:-}" ]]; then
+  if [[ -f "$WORKTREE_ROOT/build/lib/libdtvmapi.so" ]]; then
+    DTVMAPI="$WORKTREE_ROOT/build/lib/libdtvmapi.so"
+  elif [[ -f "/home/abmcar/DTVM/build/lib/libdtvmapi.so" ]]; then
+    DTVMAPI="/home/abmcar/DTVM/build/lib/libdtvmapi.so"
+  else
+    echo "error: cannot locate libdtvmapi.so" >&2
+    echo "  tried: $WORKTREE_ROOT/build/lib/libdtvmapi.so" >&2
+    echo "         /home/abmcar/DTVM/build/lib/libdtvmapi.so" >&2
+    echo "  set DTVMAPI=<path> to override" >&2
+    exit 1
+  fi
+fi
+
+EVMONE_BENCH="${EVMONE_BENCH:-/home/abmcar/evmone/build/bin/evmone-bench}"
+REPS="${REPS:-5}"
+
+if [[ ! -f "$DTVMAPI" ]]; then
+  echo "error: DTVMAPI not found: $DTVMAPI" >&2
+  exit 1
+fi
+if [[ ! -x "$EVMONE_BENCH" ]]; then
+  echo "error: EVMONE_BENCH not executable: $EVMONE_BENCH" >&2
+  exit 1
+fi
+
+VM_ARG="${DTVMAPI},mode=multipass,enable_gas_metering=true"
+
+echo "==> running evmone-bench with DTVM"
+echo "    DTVMAPI=$DTVMAPI"
+echo "    EVMONE_BENCH=$EVMONE_BENCH"
+echo "    REPS=$REPS"
+echo
+
+RESULT_JSON="$SCRIPT_DIR/result.json"
+
+# --benchmark_min_time=1x avoids re-JIT between repetitions (per
+# reference_evmone_bench_iteration_semantics: Ns re-JITs each iter).
+# --benchmark_filter restricts to our fixtures (excludes synth benches).
+"$EVMONE_BENCH" "$VM_ARG" "$SCRIPT_DIR/fixtures" \
+  --benchmark_min_time=1x \
+  --benchmark_repetitions="$REPS" \
+  --benchmark_filter='external/total/callruntime/' \
+  --benchmark_format=json > "$RESULT_JSON" 2>&1 || {
+  echo "error: evmone-bench failed; tail of output:" >&2
+  tail -n 30 "$RESULT_JSON" >&2
+  exit 1
+}
+
+# Strip the "External VM: ..." header line so the file is pure JSON.
+# (evmone-bench writes that line to stdout before the JSON body.)
+python3 - "$RESULT_JSON" <<'PY'
+import json, sys, pathlib
+p = pathlib.Path(sys.argv[1])
+raw = p.read_text()
+i = raw.find('{')
+if i > 0:
+    p.write_text(raw[i:])
+PY
+
+echo "Result saved to: $RESULT_JSON"
+echo
+
+# Compute CPU frequency in GHz for cycle conversion. lscpu gives a
+# representative "CPU MHz" or "BogoMIPS" — for the WSL2 host, use
+# the maximum from /proc/cpuinfo's "cpu MHz" entries (avoids the
+# scaled-down idle frequency).
+CPU_MHZ="$(awk -F: '/cpu MHz/ {gsub(/ /,"",$2); print $2}' /proc/cpuinfo | sort -rn | head -1)"
+if [[ -z "$CPU_MHZ" ]]; then
+  # Fallback to benchmark.json's reported mhz_per_cpu
+  CPU_MHZ="$(python3 -c "import json; d=json.load(open('$RESULT_JSON')); print(d['context']['mhz_per_cpu'])")"
+fi
+
+# Loop iteration count inside the EVM bytecode: PUSH2 0xfde8 = 65000.
+ITER_N=65000
+
+python3 - "$RESULT_JSON" "$CPU_MHZ" "$ITER_N" <<'PY'
+import json, sys
+result_path, cpu_mhz_s, iter_n_s = sys.argv[1], sys.argv[2], sys.argv[3]
+cpu_ghz = float(cpu_mhz_s) / 1000.0
+iter_n = int(iter_n_s)
+
+with open(result_path) as f:
+    data = json.load(f)
+
+# Extract MEAN cpu_time for each fixture
+means = {}
+stddevs = {}
+for b in data['benchmarks']:
+    name = b.get('aggregate_name')
+    full = b['name']
+    if name == 'mean':
+        # Strip "_mean" suffix; key by fixture-stem
+        # e.g. external/total/callruntime/mulmod_loop/loop_mean
+        parts = full.split('/')
+        stem = parts[3]
+        means[stem] = b['cpu_time']
+    elif name == 'stddev':
+        parts = full.split('/')
+        stem = parts[3]
+        stddevs[stem] = b['cpu_time']
+
+if not means:
+    print("ERROR: no aggregate (mean) results — did REPS<2?")
+    sys.exit(1)
+
+# Convert us → ns/iteration (each run is `iter_n` iterations of the bytecode loop)
+def ns_per_iter(us_per_run):
+    return us_per_run * 1000.0 / iter_n
+
+def cycles_per_iter(us_per_run):
+    return ns_per_iter(us_per_run) * cpu_ghz
+
+print(f"CPU GHz: {cpu_ghz:.3f}")
+print(f"Iterations per bytecode run: {iter_n}")
+print()
+print(f"{'Fixture':<25} {'mean_ns/run':>12} {'stddev_ns/run':>14} {'ns/iter':>10} {'cycles/iter':>13}")
+print("-" * 80)
+for stem in ['baseline_empty', 'mulmod_loop', 'addmod_loop', 'baseline_div', 'div_nonconst_loop']:
+    if stem not in means:
+        continue
+    m = means[stem]
+    s = stddevs.get(stem, 0.0)
+    # cpu_time is in us; convert to ns
+    m_ns_run = m * 1000.0
+    s_ns_run = s * 1000.0
+    ni = ns_per_iter(m)
+    ci = cycles_per_iter(m)
+    print(f"{stem:<25} {m_ns_run:>12.0f} {s_ns_run:>14.0f} {ni:>10.2f} {ci:>13.1f}")
+
+print()
+print("=== callRuntimeFor cost (test - matched baseline) ===")
+def delta_cycles(test_stem, base_stem):
+    if test_stem not in means or base_stem not in means:
+        return None, None
+    delta_us = means[test_stem] - means[base_stem]
+    delta_ns_iter = delta_us * 1000.0 / iter_n
+    delta_cycles = delta_ns_iter * cpu_ghz
+    return delta_ns_iter, delta_cycles
+
+# Map test → matched baseline
+pairs = [
+    ('mulmod_loop', 'baseline_empty', 'MULMOD callRuntimeFor (unconditional, line 2479)'),
+    ('addmod_loop', 'baseline_empty', 'ADDMOD callRuntimeFor (slow path, mod[3]==0)'),
+    ('div_nonconst_loop', 'baseline_div', 'DIV callRuntimeFor (multi-limb branch, line 1842)'),
+]
+print(f"{'Op':<45} {'delta ns/op':>12} {'cycles/op':>11}  bucket")
+print("-" * 90)
+for test, base, label in pairs:
+    dn, dc = delta_cycles(test, base)
+    if dn is None:
+        print(f"{label:<45}    MISSING (test={test}, base={base})")
+        continue
+    if dc < 20:
+        bucket = "<20"
+    elif dc < 100:
+        bucket = "20-100 gray"
+    else:
+        bucket = ">100"
+    print(f"{label:<45} {dn:>12.2f} {dc:>11.1f}  {bucket}")
+PY


### PR DESCRIPTION
## Summary

Add a **local, manually-invoked** microbench harness under
`tests/microbench/callruntimefor/` that drives `evmone-bench`
(Google Benchmark cycle counter) against hand-crafted EVM bytecode
loops which route through `callRuntimeFor` for MULMOD / ADDMOD slow
path / DIV multi-limb branch. Subtracts a matched empty-loop baseline
to isolate per-call runtime overhead.

The harness is **not** wired into CI. It exists so that whoever
designs MULMOD Barrett or a u64-narrow MULMOD inline path can
re-measure `callRuntimeFor` cost on their own hardware before
committing to those changes.

### What this PR is and is NOT

- **Is**: 5 EVM fixture JSONs in evmone-bench State-Transition-Test
  format + `run_microbench.sh` driver + spec README + initial-
  measurement record.
- **Is NOT**: a `src/` change, a CI test, an automated gate, or a
  benchmark that runs by default. Pure local tooling.

### Initial measurement (WSL2 / 3.878 GHz, two runs committed)

| Op (path) | Run 1 cycles/op | Run 2 cycles/op | Bucket |
|-----------|---:|---:|---|
| MULMOD `callRuntimeFor` unconditional (evm_mir_compiler.cpp:2479) | 245 | 209 | > 100 |
| ADDMOD slow path (evm_mir_compiler.cpp:2444-2455) | 119 | 102 | > 100 (borderline) |
| DIV multi-limb branch (evm_mir_compiler.cpp:1842-1849) | 27 | 25 | wrapper-floor (+ ~5-10 cycles intx normalize) |

MULMOD is the high-confidence signal; ADDMOD is borderline (within
WSL2 stddev/mean of the threshold). Raw `result.json` is not
committed (gitignored); the two-run table above is the authoritative
record.

## Known limitations

- Hard-coded fallback paths in `run_microbench.sh` reference
  `/home/abmcar/...`; both can be overridden via `DTVMAPI=` and
  `EVMONE_BENCH=` env vars.
- `tests/microbench/**/fixtures/` is globally ignored by
  `DTVMDotfiles/dotfiles/exclude.map.sh:25`. Fixtures are committed
  (verified `git ls-tree -r HEAD`), but local edits will be invisible
  to `git status` on developer machines with dotfiles installed. A
  separate DTVMDotfiles change is needed to add an override.

## Test plan

- `tools/format.sh check` — pass (no source change)
- No `src/` touched; build is a no-op for this PR
- Five fixtures pass evmone-bench JSON parser
  (`evmone-bench --benchmark_list_tests=true` lists all five)
- `run_microbench.sh` reproducible across the two committed runs

## DRAFT — personal fork integration test

Drafting on `abmcar/DTVM` (personal fork). Not yet for upstream.