### PR TITLE
fix(compiler): fix the remaining EVM SSA stack-lift crashes

### DIFF
--- a/docs/changes/2026-06-09-evm-ssa-lift-remaining-crashes/README.md
+++ b/docs/changes/2026-06-09-evm-ssa-lift-remaining-crashes/README.md
@@ -1,0 +1,89 @@
+# Change: Fix the remaining EVM SSA stack-lift crashes
+
+- **Status**: Implemented
+- **Date**: 2026-06-09
+- **Tier**: Light
+
+## Overview
+
+Follow-up to the phi-materialization fixes (PR #530). Fixes the remaining
+crashes in the EVM multipass JIT's SSA stack-lift path
+(`ZEN_ENABLE_EVM_STACK_SSA_LIFT`, default **OFF**). With the flag ON, the JIT
+aborted (SIGABRT) on several contracts in the EEST state-test suite and the
+mainnet-replay corpus. After this change, SSA-lift compiles both corpora
+crash-free and produces results identical to the default build. All edits are
+reachable only on the lift path; the default (flag-off) build is unaffected.
+
+## Defects and fixes
+
+### 1. Dynamic-jump shape-class entry-depth gate
+
+A block that is both a dynamic-jump target and a dynamic-jump source whose own
+`JUMP` net-pops the stack (entry depth ≠ exit depth) crashed:
+`getCompatibleDynamicJumpTargetBlocksForSourceBlock` reused the block's target
+shape class as its source class, assuming it re-dispatches at the depth it
+entered. Its shallow exit stack was then assigned as a deeper region's entry
+state, tripping `EntryDepth == Values.size()`.
+
+Fix (`evm_analyzer.h`): gate the fallback on the source block's
+`ResolvedExitStackDepth` equalling the candidate shape class's entry depth (new
+helper `getDynamicJumpShapeClassEntryDepth`). This enforces the source side of
+the invariant `source-exit-depth == target-entry-depth == shape-class-entry-depth`,
+which was previously checked only on the target side.
+
+### 2. JUMPDEST double-begin
+
+When a `JUMP`/`JUMPI` terminator falls through into a `JUMPDEST`, the
+terminator handler begins the fallthrough block and the main loop's `JUMPDEST`
+handler then begins the same block again. With the flag OFF this is benign;
+with SSA-lift ON the second begin (a) records a self-edge
+`PredBlockPC == BlockPC` absent from the predecessor order (→ `getPhiIncomingSlot`
+abort), and (b) re-restores the lifted logical entry state, doubling the logical
+stack (→ entry-depth mismatch abort).
+
+Fix (`evm_bytecode_visitor.h`): detect `RunStartPC == CurrentBlockEntryPC`
+(gated on `CurrentBlockLifted`), skip the redundant edge assignment, and drain
+the stale logical-stack copy so the entry state is restored exactly once.
+
+### 3. Operand identity key on a non-U256 operand
+
+`getOperandIdentityKey` dereferenced `getU256VarComponents()` based only on a
+compile-time type check, so an empty/deferred operand (not multi-component) hit
+the "Not a multi-component U256" assertion.
+
+Fix (`evm_lifted_stack_lifter.h`): add a runtime `isU256MultiComponent()` guard;
+non-multi-component operands fall through to the opaque-key path.
+
+## Impact
+
+- **Modules**: `src/action/evm_bytecode_visitor.h`,
+  `src/compiler/evm_frontend/evm_analyzer.h`,
+  `src/compiler/evm_frontend/evm_lifted_stack_lifter.h`.
+- **Default build (flag OFF)**: unaffected (each fix is lift-path-gated).
+
+## Validation
+
+- **Lift path (flag ON)**:
+  - multipass `evmone-unittests`: **223/223**
+  - multipass `evmone-statetest -k fork_Cancun` (EEST): **2723/2723, 0 failed,
+    no SIGABRT** — matches the default-build baseline exactly
+  - 227-fixture mainnet-replay corpus: no SIGABRT; failing-test set identical to
+    the default build (0 regressions)
+- **Default path (flag OFF, rebuilt from this change)**: multipass
+  `evmone-unittests` **223/223**, `evmone-statetest -k fork_Cancun` **2723/2723**.
+- `tools/format.sh check`: passes.
+
+## Known residual (not a crash)
+
+The EEST run still emits five benign `PredBlockPC == BlockPC` self-edge cases on
+single-predecessor blocks (no merge phis, no abort, all tests pass). They point
+to a residual double-begin path not covered by the `CurrentBlockLifted`-gated
+guard; addressing them would require a broader audit of the terminator/JUMPDEST
+begin handshake rather than a surgical change.
+
+## Checklist
+
+- [x] Implementation complete
+- [x] Lift-path crash-free on EEST statetest + replay corpus
+- [x] Default-path neutrality (unittests 223/223, statetest 2723/2723)
+- [x] Build and format checks pass

--- a/src/action/evm_bytecode_visitor.h
+++ b/src/action/evm_bytecode_visitor.h
@@ -810,7 +810,33 @@ private:
           if (PC > RunStartPC && HasLiveFallthrough) {
             Builder.meterOpcodeRange(RunStartPC, PC);
           }
-          if (HasLiveFallthrough && tryAssignFallthroughEntryState(PC)) {
+          // When a JUMP/JUMPI terminator falls through into a JUMPDEST, the
+          // terminator handler already called handleBeginBlock for the
+          // fallthrough target before the JUMPDEST opcode is decoded, so the
+          // block currently being decoded IS this JUMPDEST's block
+          // (CurrentBlockEntryPC == RunStartPC). Its incoming entry edge was
+          // already assigned by the predecessor terminator. Re-running the
+          // fallthrough-edge assignment here would record a spurious self-edge
+          // (PredBlockPC == BlockPC) that is absent from the block's
+          // predecessor order, corrupting phi incoming-slot bookkeeping. Skip
+          // the redundant edge assignment in that case (gated on
+          // CurrentBlockLifted so the flag-OFF path is unchanged);
+          // handleJumpDest + the re-begin below still run to wire the body
+          // branch and re-materialize the lifted entry state in the canonical
+          // JUMPDEST body block.
+          bool AlreadyBegunLiftedEntry = HasLiveFallthrough &&
+                                         CurrentBlockLifted &&
+                                         RunStartPC == CurrentBlockEntryPC;
+          if (AlreadyBegunLiftedEntry) {
+            // Entry edge already assigned by the predecessor terminator; do not
+            // reassign. The predecessor's handleBeginBlock already restored
+            // this block's lifted logical entry state onto the logical stack.
+            // The re-begin below (handleBeginBlock after handleJumpDest)
+            // restores it again in the canonical JUMPDEST body block, so drain
+            // the stale copy first to prevent the logical stack from being
+            // doubled.
+            drainLogicalStack();
+          } else if (HasLiveFallthrough && tryAssignFallthroughEntryState(PC)) {
             // Keep runtime stack materialization elided on lifted fallthrough.
           } else {
             if (HasLiveFallthrough && CurrentBlockLifted && isLiftedBlock(PC)) {

--- a/src/compiler/evm_frontend/evm_analyzer.h
+++ b/src/compiler/evm_frontend/evm_analyzer.h
@@ -250,6 +250,23 @@ public:
     return ShapeClassIds.size() == 1 ? ShapeClassIds.front() : 0;
   }
 
+  // Returns the uniform entry-state depth (FullEntryStateDepth) associated
+  // with a dynamic-jump shape class, or -1 if the class is unknown. All
+  // regions sharing a ShapeClassId have the same FullEntryStateDepth by
+  // construction (see finalizeDynamicJumpRegionMetadata's ShapeKey).
+  int32_t getDynamicJumpShapeClassEntryDepth(uint32_t ShapeClassId) const {
+    if (ShapeClassId == 0) {
+      return -1;
+    }
+    for (const auto &[RegionEntryPC, RegionInfo] : DynamicJumpRegions) {
+      (void)RegionEntryPC;
+      if (RegionInfo.ShapeClassId == ShapeClassId) {
+        return RegionInfo.FullEntryStateDepth;
+      }
+    }
+    return -1;
+  }
+
   uint32_t
   getOutgoingCompatibleDynamicJumpShapeClassForBlock(uint64_t BlockPC) const {
     auto It = BlockInfos.find(BlockPC);
@@ -345,8 +362,22 @@ public:
     uint32_t OutgoingShapeClassId =
         getOutgoingCompatibleDynamicJumpShapeClassForBlock(BlockPC);
     if (OutgoingShapeClassId == 0 && It->second.HasDynamicJump) {
-      OutgoingShapeClassId =
+      // Fallback: a block that is itself a dynamic-jump target candidate may
+      // re-dispatch through the same shape class it belongs to. This is only
+      // valid when the block re-dispatches at the depth that class expects on
+      // entry. A block whose dynamic JUMP leaves a different outgoing depth
+      // (e.g. it net-pops part of its entry stack) must NOT propagate its
+      // outgoing stack into that class's targets, or the assigned entry state
+      // would be the wrong size. Gate on the source's resolved exit depth.
+      const uint32_t CandidateShapeClassId =
           getUniqueCompatibleDynamicJumpShapeClassForBlock(BlockPC);
+      const int32_t CandidateEntryDepth =
+          getDynamicJumpShapeClassEntryDepth(CandidateShapeClassId);
+      if (CandidateShapeClassId != 0 &&
+          It->second.ResolvedExitStackDepth >= 0 &&
+          It->second.ResolvedExitStackDepth == CandidateEntryDepth) {
+        OutgoingShapeClassId = CandidateShapeClassId;
+      }
     }
     if (OutgoingShapeClassId != 0) {
       std::vector<uint64_t> TargetBlockPCs;

--- a/src/compiler/evm_frontend/evm_lifted_stack_lifter.h
+++ b/src/compiler/evm_frontend/evm_lifted_stack_lifter.h
@@ -414,13 +414,21 @@ private:
     }
 
     if constexpr (HasGetU256VarComponents<Operand>::value) {
-      const auto &VarComponents = Value.getU256VarComponents();
-      std::string Key = "u256vars";
-      for (const auto *Var : VarComponents) {
-        Key += ':';
-        appendPointerKey(Key, Var);
+      // Only a multi-component U256 operand backed by variables exposes a
+      // stable var-component identity. getU256VarComponents() asserts on
+      // IsU256MultiComponent, so an operand that reaches here without being a
+      // multi-component value (e.g. an empty/deferred operand whose Instr and
+      // Var accessors both returned null) must fall through to an opaque key
+      // rather than dereferencing the var-component array.
+      if (Value.isU256MultiComponent()) {
+        const auto &VarComponents = Value.getU256VarComponents();
+        std::string Key = "u256vars";
+        for (const auto *Var : VarComponents) {
+          Key += ':';
+          appendPointerKey(Key, Var);
+        }
+        return Key;
       }
-      return Key;
     }
 
     std::string Key = "opaque:";


### PR DESCRIPTION
## What

Follow-up to #530. Fixes the remaining crashes in the EVM multipass JIT's SSA
stack-lift path (`ZEN_ENABLE_EVM_STACK_SSA_LIFT`, default **OFF**). After this
change, SSA-lift compiles the full EEST state-test suite and the mainnet-replay
corpus crash-free, producing results identical to the default build.

> **Stacked on #530.** Base is the #530 branch; this PR's diff is only the
> follow-up commits. Review/merge after #530. (Once #530 lands on upstream
> `main`, this will be retargeted to `main`.)

## The remaining bugs

1. **Dynamic-jump shape-class entry-depth gate** — a block that is both a
   dynamic-jump target and a dynamic-jump source whose own `JUMP` net-pops the
   stack (entry depth ≠ exit depth) had its shallow exit stack assigned as a
   deeper region's entry state → `EntryDepth == Values.size()` abort. Gate the
   shape-class fallback on the source's exit depth matching the class entry
   depth (`evm_analyzer.h`).

2. **JUMPDEST double-begin** — when a `JUMP`/`JUMPI` terminator falls through
   into a `JUMPDEST`, both the terminator handler and the main loop begin the
   same block. Benign with the flag OFF; with SSA-lift ON it adds a self-edge
   `PredBlockPC == BlockPC` (→ `getPhiIncomingSlot` abort) and re-restores the
   lifted entry state (→ depth-mismatch abort). Detect the re-begin
   (`RunStartPC == CurrentBlockEntryPC`, gated on `CurrentBlockLifted`), skip the
   redundant edge, and drain the stale logical-stack copy (`evm_bytecode_visitor.h`).

3. **Operand identity key on a non-U256 operand** — `getOperandIdentityKey`
   dereferenced `getU256VarComponents()` on a compile-time type check alone, so
   an empty/deferred operand hit the "Not a multi-component U256" assert. Add a
   runtime `isU256MultiComponent()` guard (`evm_lifted_stack_lifter.h`).

All three are reachable only on the lift path; the default (flag-off) build is
unaffected.

## Validation

| Suite | Flag | Result |
|---|---|---|
| multipass `evmone-unittests` | ON | 223/223 |
| multipass `evmone-statetest -k fork_Cancun` (EEST) | ON | **2723/2723, 0 failed, no SIGABRT** |
| 227-fixture mainnet-replay corpus | ON | no SIGABRT; fail-set identical to OFF (0 regressions) |
| multipass `evmone-unittests` | OFF | 223/223 |
| multipass `evmone-statetest -k fork_Cancun` | OFF | 2723/2723 |
| `tools/format.sh check` | — | passes |

The lift-path EEST result matches the default-build baseline exactly.

## Known residual (not a crash)

The EEST run still emits five benign `PredBlockPC == BlockPC` self-edge cases on
single-predecessor blocks (no merge phis, no abort, all tests pass). Clearing
them would need a broader audit of the terminator/JUMPDEST begin handshake
rather than a surgical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
